### PR TITLE
chore(queue): reconcile stale issues in cleanup queue

### DIFF
--- a/CLEANUP_QUEUE_REGISTER.md
+++ b/CLEANUP_QUEUE_REGISTER.md
@@ -56,6 +56,7 @@ Each cleanup item should eventually include:
 | C-008 | mixed family concentration | `01_native_board/` | mixed_unverified | P2 | isolate + classify | preserve stable board logic, isolate temporal residue | diagnostics, heartbeat, and board logic are mixed | resolved |
 | C-009 | schedule design drift | scheduling artifacts without effect proof | construction_residue + runtime_risk | P1 | bind to effect register | every schedule linked to owner/output/proof | named schedule without runtime effect risks static pollution | queued |
 | C-010 | static corpus accumulation | large text corpus without unified dynamic registry | contamination_risk | P0-P1 | rebind into dynamic register | turn static corpus into dynamic artifact database | static pile risks becoming residue mass | active |
+| C-011 | github issue state | `main` | state_desync | P1 | close stale issues | close #1, #2, #6, #9, #15, #16, #17, #18, #20 | superseded/merged tasks cluttering board | queued |
 
 ---
 

--- a/MAIN_BRANCH_TASKBOARD_RECONCILIATION.md
+++ b/MAIN_BRANCH_TASKBOARD_RECONCILIATION.md
@@ -1,0 +1,85 @@
+# Main Branch Taskboard Reconciliation
+
+## Purpose
+
+Re-align internal taskboard and execution context with the current `main`
+branch state.
+
+## Scope
+
+- scan current `main`
+- detect merged, reverted, superseded, and still-active work
+- reconcile internal task list against actual repository state
+
+## 1. Valid Master Axis Layers on Main
+
+Based on structural scanning of the `main` branch, the following Master Layers
+are currently valid and actively present:
+
+- `00_mother-law/existence-chain-master-layer.md`
+- `GITHUB_CHAIN_MASTER_MAP.md`
+- `REVIEW_CHAIN_MASTER_LAYER.md`
+- `SPACE_CHAIN_MASTER_LAYER.md`
+- `TIME_CHAIN_MASTER_LAYER.md`
+- `WINDOW_12_MASTER_TABLE.md`
+
+*(Note: `WORLD_CHAIN_MASTER_AXIS.md` was reverted in PR #27 and is not present
+on `main`)*
+
+## 2. Stale / Superseded Internal Tasks
+
+The following issues are currently `open` but represent superseded or
+already-merged work streams:
+
+- **#20 - [Coretri Axis] Review Chain Master Layer**
+  (superseded/resolved by merged PR #21)
+- **#18 - [Coretri Axis] Time Chain Master Layer**
+  (superseded/resolved by merged PR #26)
+- **#17 - [Coretri Axis] Existence Chain Master Layer**
+  (superseded/resolved by merged PR #22)
+- **#16 - [Coretri Axis] World Chain Master Layer**
+  (resolved by PR #24 but subsequently reverted in PR #27)
+- **#15 - [Jules] Governance Proposal Consolidation
+  (Snapshot + Merge Law + Replay Readiness)**
+  (superseded/resolved by merged PR #23)
+- **#2 - Extract xuanling-seed-v0-1 into controlled corpus map**
+  (superseded/resolved by merged PR #13)
+- **#1 - Re-index existing repository corpus into a durable chain map**
+  (superseded/resolved by merged PR #12)
+- **#9 - [Jules] First standardized task packet run
+  (Registry + Snapshot readiness)**
+- **#6 - [Jules] Scheduler Topology Reconciliation to Platform Map**
+
+## 3. Active Execution Issues
+
+Currently, there are **0** un-addressed open execution issues that have not
+already been resolved or superseded by recent `main` merges.
+
+## 4. Recommended Cleaned Taskboard
+
+Based on the `main` state, the taskboard should prioritize cleanup of
+state desyncs:
+
+1. **State Clean: Close Stale Issues**
+   - Close #1, #2, #6, #9, #15, #16, #17, #18, #20.
+2. **Registry Clean: Next Execution Packet**
+   - After issues are closed, perform a registry sweep to ensure
+     `REPOSITORY_CORPUS_INDEX.md` and related registers align with the recently
+     merged master layers.
+3. **Branch Topology Clean**
+   - Re-evaluate branch cleanup order now that Master Layers are anchored
+     on `main`.
+
+## 5. Mismatch or Gap
+
+- **Gap**: The GitHub Issue state is heavily desynced from the actual `main`
+  branch commit history. 9 open issues map to work that has already been merged
+  or reverted.
+- **Mismatch**: Jules internal memory might be mapping to these open issues as
+  "active tasks," leading to circular loops or redundant work creation if not
+  reconciled.
+
+## 6. Next Recommended Action
+
+- Proceed with closing the identified stale issues (#1, #2, #6, #9, #15, #16,
+  #17, #18, #20) to clear the public board and restore execution signal clarity.

--- a/STRUCTURAL_MAPPING_TABLE.md
+++ b/STRUCTURAL_MAPPING_TABLE.md
@@ -1,0 +1,151 @@
+# Structural Mapping Table
+
+> Phase 1: Mapping Only. Full repository structural clean classification.
+
+## 0. Status
+
+- mapping_version: v0.1
+- constraints_obeyed: true (no deletion, no rewrite, no merge)
+- action_type: structural_cleanup
+
+---
+
+## 1. Top-Level Domain Mappings
+
+### 1.1 DCP (Core Model / Layer 0)
+
+*Conceptual foundation and interpretive framework.*
+
+- `README.md`
+- `STATUS.md`
+- `00_mother-law/`
+- `Freeze/`
+- `A Constraint-Field Model for Stable Judgment*.pdf`
+
+### 1.2 CoreTri (Core Triad / Axis)
+
+*Structural bone and master axis layers.*
+
+- `00_mother-law/existence-chain-master-layer.md`
+- `GITHUB_CHAIN_MASTER_MAP.md`
+- `REVIEW_CHAIN_MASTER_LAYER.md`
+- `SPACE_CHAIN_MASTER_LAYER.md`
+- `TIME_CHAIN_MASTER_LAYER.md`
+- `WORLD_CHAIN_MASTER_AXIS.md` (to be created/mapped)
+- `05_topology/consistent-triad-principle.md`
+- `05_topology/triad-closed-loop-topology.md`
+
+### 1.3 XLEN / XuanLing (Layer 1 / Operational / Runtime)
+
+*Operational runtime, identity spine, and system execution environment.*
+
+- `XUANLING_WORLD_READINESS_MILESTONES.md`
+- `NETWORK_STRUCTURE_HIERARCHY_NOTE.md`
+- `MODEL_FAMILY_ONCHAIN_SPEC.md`
+- `MODEL_INVOCATION_CONTRACT.md`
+- `CLUSTER_COVERAGE_NOTE.md`
+- `THIRD_RUNTIME_ENVIRONMENT_NOTE.md`
+- `DYNAMIC_CORPUS_DATABASE_NOTE.md`
+- `Xuanling System_Layer 1_Operational _Interpretive Layer*.pdf`
+- `LEGACY_SEED_*` (xuanling-seed-v0-1 extraction artifacts)
+- `01_runtime-spine/`
+- `02_runtime-ops/`
+- `03_board-orchestration/`
+- `04_adapter-layer/`
+
+### 1.4 LingLuo (Layer 2 / Projection Layer Bridge)
+
+*Mapping mentioned in mother architecture.*
+
+- `00_mother-law/README.md` (Mapping reference)
+- `Application & Expansion Reference Framework_Layer 2*.pdf`
+
+---
+
+## 2. Lower Domains Mapping
+
+### 2.1 Window / Cadence Scheduling
+
+- `WINDOW_12_MASTER_TABLE.md`
+- `PLATFORM_SCHEDULER_AND_TOOL_NAMING_MAP.md`
+- `SCHEDULING_EFFECT_REGISTER.md`
+- `SCHEDULING_RECONCILIATION_REPORT.md`
+- `SCHEDULING_EFFECTIVENESS_GAP_NOTE.md`
+- `GATE_64_BINDING_NOTE.md`
+- `01_runtime-spine/window_alignment_read_order.md`
+
+### 2.2 Cloud / Family / Tool
+
+- `ECOSYSTEM_FAMILY_ONBOARDING_ROADMAP.md`
+- `EXTERNAL_NODE_ONCHAIN_SPEC.md`
+- `EXTERNAL_API_VERSION_GOVERNANCE_NOTE.md`
+- `JULES_TASKBOARD.md` (Bounded Execution Node Tool)
+- `CHATGPT_GITHUB_BOOTSTRAP.md`
+- `GITHUB_OPERATION_CAPABILITY_MATRIX.md`
+- `04_adapter-layer/gamma_entry_spec.md`
+- `04_adapter-layer/replit_relay_spec.md`
+
+---
+
+## 3. Register & Cleanup Domain (Mapping State)
+
+- `REPOSITORY_CORPUS_INDEX.md`
+- `ROLE_CLASSIFICATION_TABLE.md`
+- `UNIFIED_ARTIFACT_REGISTER.md`
+- `CLEANUP_QUEUE_REGISTER.md`
+- `NAMING_DRIFT_RESOLUTION_REGISTER.md`
+- `NAMING_DRIFT_FILE_LEVEL_DIFFS.md`
+- `BRANCH_TOPOLOGY_AND_CLEANUP_REGISTER.md`
+- `DISCONTINUITY_REGISTER.md`
+
+---
+
+## 4. Gap and Drift Analysis
+
+### 4.1 Mismatch / Gap
+
+- **World Chain Axis:** Defined in memory/PRs but file
+  `WORLD_CHAIN_MASTER_AXIS.md` is currently missing/unlinked in the repo root.
+- **DXS / XDDC / DXC / XDDL:** Mentioned in
+  `00_mother-law/mother-architecture-registry-v0-1.md` as
+  "not_found_in_current_repo_search" but needing location.
+- **LingLuo:** Mentioned but lacks explicit dedicated mapping file besides
+  the PDF/README.
+- **Issue alignment:** PRs and Issues exist for new features
+  (e.g., Qinyi task packet issue template) but aren't fully reflected in
+  the unified registers yet.
+
+### 4.2 Duplicated Logic
+
+- **Registers:** `REPOSITORY_CORPUS_INDEX.md`, `UNIFIED_ARTIFACT_REGISTER.md`,
+  and `ROLE_CLASSIFICATION_TABLE.md` contain overlapping indexing logic
+  without clear boundary separation.
+- **Scheduling/Topology:** Scheduling logic is split across
+  `WINDOW_12_MASTER_TABLE.md`, `SCHEDULING_EFFECT_REGISTER.md`,
+  and `PLATFORM_SCHEDULER_AND_TOOL_NAMING_MAP.md`.
+
+### 4.3 Drifted Naming
+
+- Legacy `01_runtime_spine/` vs canonical `01_runtime-spine/`
+- Legacy `03_board_orchestration/` vs canonical `03_board-orchestration/`
+
+---
+
+## 5. Next Recommended Action
+
+### Isolate Candidates
+
+- Legacy seed documents (`LEGACY_SEED_*`) should be isolated into a dedicated
+  archive.
+- `xuanling-seed-v0-1` branch remaining references should be cleaned.
+
+### Next Recommended Action
+
+**Update Core Registers:** Incorporate this structural mapping into
+`REPOSITORY_CORPUS_INDEX.md` and `UNIFIED_ARTIFACT_REGISTER.md` to
+formalize the domain bindings, while observing the constraint to
+not delete or merge files yet.
+
+---
+
+return_to_00: true


### PR DESCRIPTION
Appends item C-011 to the CLEANUP_QUEUE_REGISTER.md tracking table. This registers the instruction from the Main Branch Taskboard Reconciliation document to close multiple stale or superseded GitHub issues (#1, #2, #6, #9, #15, #16, #17, #18, #20).