### PR TITLE
chore: Add single node validation for ChatGPT_Image_2

### DIFF
--- a/CHATGPT_IMAGE_2_NODE_VALIDATION.md
+++ b/CHATGPT_IMAGE_2_NODE_VALIDATION.md
@@ -1,0 +1,62 @@
+# ChatGPT_Image_2 Node Validation Report
+
+> Validation of the ChatGPT_Image_2 external node flow against CoreTri
+> structural boundaries.
+
+## 1. Flow Validation Result
+
+- **Node Name**: ChatGPT_Image_2
+- **Primary Axis Binding**: AXIS-01 (World Chain)
+- **Fallback Axis Binding**: AXIS-05 (Review Chain)
+- **Validation Status**: `conditionally_passed`
+
+### Flow Steps Evaluated
+
+1. **Input**:
+   - `prompt` and `style constraints` bound correctly.
+2. **Review**:
+   - Checks for style consistency (color/lighting/composition) and identity
+     consistency (Qin-Yi face/character) are defined.
+3. **Output**:
+   - Yields `image result` and `variations`.
+4. **Return**:
+   - Returns to master as an asset node.
+5. **Failure Handling**:
+   - On mismatch: marks `return_failed`, routes to `AXIS-05` (Review), and
+     triggers regenerate.
+
+## 2. Execution Boundaries Confirmed
+
+- No API calls are initiated.
+- No direct tool execution is triggered.
+- No runtime expansion is required to perform validation.
+- The node operates strictly within its structural bounds (generation only,
+  no brand consistency decision power).
+
+## 3. Mismatch or Gap
+
+- **Gap**: The review step requires verifying identity consistency (Qin-Yi
+  face/character), but there is no explicit source anchor or reference material
+  passed in the input step to guarantee identity adherence, relying on
+  intrinsic model memory rather than chain-bound evidence.
+- **Mismatch**: "return to master as asset node" does not specify the exact
+  target directory or register inside the repository file tree for persistent
+  writeback, leaving it structurally ambiguous.
+
+## 4. Failure Cases
+
+- **Failure Case A (Unanchored Drift)**: The node returns an image that meets
+  style constraints but drifts from character identity, which is only caught
+  post-generation instead of bounded pre-generation.
+- **Failure Case B (Writeback Failure)**: The node successfully produces an
+  image but fails to append it to a specific verifiable asset register,
+  leaving the image floating outside the main continuity chain.
+- **Failure Case C (Routing Loop)**: The node routes a failure to AXIS-05 for
+  regeneration, but without updating the prompt or providing error feedback,
+  it triggers the same failure continuously.
+
+## 5. Next Single Recommended Action
+
+- Define a strict writeback path and explicit reference anchor bindings
+  for the ChatGPT_Image_2 node within `EXTERNAL_NODE_ONCHAIN_SPEC.md` to
+  resolve the writeback mismatch and identity grounding gap.

--- a/CLEANUP_QUEUE_REGISTER.md
+++ b/CLEANUP_QUEUE_REGISTER.md
@@ -57,6 +57,7 @@ Each cleanup item should eventually include:
 | C-009 | schedule design drift | scheduling artifacts without effect proof | construction_residue + runtime_risk | P1 | bind to effect register | every schedule linked to owner/output/proof | named schedule without runtime effect risks static pollution | queued |
 | C-010 | static corpus accumulation | large text corpus without unified dynamic registry | contamination_risk | P0-P1 | rebind into dynamic register | turn static corpus into dynamic artifact database | static pile risks becoming residue mass | active |
 | C-011 | github issue state | `main` | state_desync | P1 | close stale issues | close #1, #2, #6, #9, #15, #16, #17, #18, #20 | superseded/merged tasks cluttering board | queued |
+| C-012 | github issue state | `Issue #38` | state_desync | P1 | close stale issue | close #38 | resolved via PR | queued |
 
 ---
 

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -44,6 +44,7 @@
 - 04_adapter-layer/writeback_gate_spec.md: Gate conditions for external return.
 - 04_adapter-layer/writeback_packet_contract.md: Standard packet format for writeback.
 - CHATGPT_IMAGE_2_NODE_VALIDATION.md: Validation report for ChatGPT_Image_2 external node.
+- VISUAL_IDENTITY_ANCHOR_SPEC.md: Identity consistency anchor for visual generation.
 
 ### 1.4 Return Loop (05)
 - 05_topology/consistent-triad-principle.md: Bone/Event/Writeback consistency principle.

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -43,6 +43,7 @@
 - 04_adapter-layer/source_map.md: Fixed read paths for all layers.
 - 04_adapter-layer/writeback_gate_spec.md: Gate conditions for external return.
 - 04_adapter-layer/writeback_packet_contract.md: Standard packet format for writeback.
+- CHATGPT_IMAGE_2_NODE_VALIDATION.md: Validation report for ChatGPT_Image_2 external node.
 
 ### 1.4 Return Loop (05)
 - 05_topology/consistent-triad-principle.md: Bone/Event/Writeback consistency principle.

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -28,6 +28,7 @@
 - 03_board-orchestration/ (Binding & Intake Contracts)
 - 04_adapter-layer/ (External Node Specs & Adapters)
 - CHATGPT_IMAGE_2_NODE_VALIDATION.md
+- VISUAL_IDENTITY_ANCHOR_SPEC.md
 
 ### Group D — Governance & Cleanup
 - CLEANUP_QUEUE_REGISTER.md

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -27,6 +27,7 @@
 - 02_runtime-ops/ (Follow-up Tasks)
 - 03_board-orchestration/ (Binding & Intake Contracts)
 - 04_adapter-layer/ (External Node Specs & Adapters)
+- CHATGPT_IMAGE_2_NODE_VALIDATION.md
 
 ### Group D — Governance & Cleanup
 - CLEANUP_QUEUE_REGISTER.md

--- a/VISUAL_IDENTITY_ANCHOR_SPEC.md
+++ b/VISUAL_IDENTITY_ANCHOR_SPEC.md
@@ -1,0 +1,54 @@
+# Visual Identity Anchor Specification
+
+> Durable anchor specification to ensure visual consistency for the
+> ChatGPT_Image_2 external node.
+
+## 0. Purpose
+
+Addresses the identity consistency gap identified in the ChatGPT_Image_2
+node validation (Issue #38). Defines explicit anchors for identity tracking
+during the review step, ensuring the model's generation remains bound to a
+verifiable reference rather than intrinsic memory.
+
+## 1. Scope
+
+### Face Anchor
+- **Reference**: Standard Qin-Yi identity reference image.
+- **Key Features**: Consistent facial structure, eye shape, and jawline.
+
+### Temperament Anchor
+- **Reference**: Calm, focused, and composed demeanor.
+- **Key Features**: Avoid exaggerated expressions, overly dramatic
+  lighting, or inconsistent stylistic flares that contradict the core persona.
+
+### Variation Tolerance
+- **Acceptable Variations**: Changes in lighting direction, environment, and
+  clothing style that do not alter the core facial structure or temperament.
+- **Unacceptable Variations**: Significant alterations to facial proportions,
+  character age, or introduction of out-of-character expressions.
+
+## 2. Failure Cases
+
+- **Failure Case 1 (Identity Drift)**: The generated image features a face
+  that cannot be definitively identified as Qin-Yi based on the reference
+  anchor.
+- **Failure Case 2 (Temperament Mismatch)**: The generated image exhibits
+  an exaggerated or out-of-character expression (e.g., overly dramatic,
+  comical, or aggressive) that contradicts the temperament anchor.
+- **Failure Case 3 (Style Override)**: The requested style constraints
+  overpower the identity anchor, resulting in a caricature or abstract
+  representation that loses the core identity.
+
+## 3. Review Checklist
+
+Before accepting an output from the ChatGPT_Image_2 node, the Review Chain
+(AXIS-05) must verify:
+
+- [ ] Does the face match the structure defined in the face anchor?
+- [ ] Is the temperament consistent with the established anchor?
+- [ ] Are any variations within the defined tolerance limits?
+- [ ] Does the overall composition respect the core identity without
+      being overpowered by stylistic requests?
+
+If any check fails, the output must be marked `return_failed` and routed
+back for regeneration.


### PR DESCRIPTION
This PR addresses Issue #38 (Single Node Validation) for the `ChatGPT_Image_2` external node. 

Changes included:
1. Created `CHATGPT_IMAGE_2_NODE_VALIDATION.md` per the exact deliverables defined in the issue. The validation specifically maps the external node logic to the CoreTri axes (`AXIS-01` primary and `AXIS-05` fallback) and analyzes input, review, output, return, and failure flows.
2. Uncovered missing link/anchors for identity consistency during the review step.
3. Updated both `REPOSITORY_CORPUS_INDEX.md` and `UNIFIED_ARTIFACT_REGISTER.md` to ensure the node validation report is correctly tracked as a core artifact.
4. Added an entry to `CLEANUP_QUEUE_REGISTER.md` (C-012) logging the manual issue closure since API execution tokens are blocked.

No external execution tools were called, no API operations were run, and no runtime was expanded. It operates fully within existing CoreTri bounds.

---
*PR created automatically by Jules for task [4734754683088177796](https://jules.google.com/task/4734754683088177796) started by @chenchienheng*