### PR TITLE
feat: establish LINE External Entry Chain specification

### DIFF
--- a/04_adapter-layer/line_entry_chain_spec.md
+++ b/04_adapter-layer/line_entry_chain_spec.md
@@ -1,0 +1,100 @@
+# LINE Entry Chain Specification
+
+Department: Adapter Layer
+Node ID: ADP-LINE-001
+Window: W0
+Version: v0.1
+
+## Core Purpose
+Establish the first real-world entry point using LINE as an AXIS-01 entry node.
+This node serves as the primary external interface for direct user interactions,
+routing incoming messages through the established CoreTri axis framework.
+
+## Axis Mapping
+- **Primary Axis:** AXIS-01 (World Chain) - Entry point for external events.
+- **Fallback Axis:** AXIS-05 (Review Chain) - Fallback for review and failure.
+
+## Flow Diagram
+
+```text
+[LINE User]
+   | (Message)
+   v
+[LINE Webhook]
+   | (JSON Payload)
+   v
+[AI Processing Node]
+   | (Parsed Intent & Draft)
+   v
+[Review Gate (AXIS-01 / AXIS-05)]
+   | (Approval / Adjustment)
+   v
+[Reply Assembly]
+   | (Formatted Response)
+   v
+[LINE Reply API] -> [LINE User]
+   |
+   v
+[Return Path (Writeback)]
+```
+
+## Data Formats
+
+### Message Input Format
+- **Type:** JSON (LINE Messaging API Webhook standard)
+- **Key Fields:**
+  - `replyToken`: String for immediate reply routing.
+  - `source.userId`: Unique identifier for user context.
+  - `message.text`: The raw text string of the message.
+  - `timestamp`: Event timing for temporal alignment.
+
+### Reply Output Format
+- **Type:** JSON (LINE Messaging API Reply standard)
+- **Constraints:**
+  - Max 5 message objects per reply.
+  - Text length bounds: Max 5000 characters per text object.
+  - Must include contextual reference if returning from delayed review.
+
+## Resource Constraints
+
+### Cost and Quota Constraints
+- **Target:** 0 API execution cost during specification phase.
+- **Quota Limit:** Must adhere to LINE free tier limits.
+- **Token Usage:** 0 token usage (no active LLM generation in this phase).
+
+### Rate Limits
+- No more than 1 webhook request processed per second.
+- Excessive inputs must be queued or dropped to prevent cascading overload.
+
+## Routing Paths
+
+### Review Path
+- All generated responses must route through AXIS-01 for structural validation.
+- Requires explicit verification of intent before dispatching a reply.
+
+### Return Path
+- Successful interactions must generate a minimal interaction log.
+- Logs are routed to the Writeback Chain for durable storage.
+
+### Return Failed
+- Any failure in webhook parsing, AI processing, or rate limiting must trigger a
+  `return_failed` route directly to AXIS-05 for human or manual review.
+
+## Required Credentials Checklist
+- [ ] LINE Channel ID
+- [ ] LINE Channel Secret
+- [ ] LINE Channel Access Token
+- [ ] Webhook URL (configured in LINE Developer Console)
+
+## Analysis
+
+### Mismatch or Gap
+- Webhook endpoints require a live server, which violates the "no deployment"
+  constraint of the current phase.
+- Asynchronous review (AXIS-05) may cause the `replyToken` to expire (LINE
+  tokens expire quickly), requiring fallback to Push API (which has different
+  quota limits).
+
+### Next Single Recommended Action
+- Draft a static JSON mock of the webhook payload to simulate the input
+  without requiring a live LINE application deployment.

--- a/EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
+++ b/EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
@@ -1,0 +1,63 @@
+# External Signal Entry Chain Specification
+
+Department: Adapter Layer / Core
+Node Type: External Signal Entry Node
+Version: v0.1
+
+## Core Purpose
+Define a tool-agnostic external signal entry chain for all inbound external
+triggers. This specification treats messaging platforms, web inputs,
+webhook/API inputs, crawler inputs, telecom signals, and IoT sensor signals
+as interchangeable entry nodes rather than unique or isolated integrations.
+
+## Axis Mapping
+- **Primary Axis:** AXIS-01 (World Chain) - Universal entry point.
+- **Secondary Axis:** AXIS-05 (Review Chain) - Universal fallback/failure gate.
+
+## Common Fields Definition
+Every external entry node must declare the following parameters to be
+considered compliant with the runtime:
+
+- `entry_type`: The category of the inbound signal (messaging, webhook, sensor).
+- `platform_or_protocol`: The specific service or standard (LINE, HTTP, SMS).
+- `signal_format`: The structural format of the inbound data (JSON, Plaintext).
+- `authentication_boundary`: How the signal proves its origin or authorization.
+- `cost_or_quota_constraint`: Strict bounds on execution cost and rate limits.
+- `primary_axis`: Must be AXIS-01.
+- `secondary_axis`: AXIS-05 or specific internal routing chain.
+- `review_path`: The mandatory gateway for signal verification before action.
+- `return_path`: The destination for logs, output, or writeback archiving.
+- `return_failed`: Must route to AXIS-05 for human/manual recovery.
+- `replaceability_rule`: The exact mechanism by which this entry node can be
+  swapped for an equivalent node without causing runtime collapse.
+
+## Example Mapping Table
+
+| Node | Entry Type | Format | Replaceability |
+|---|---|---|---|
+| LINE | Messaging | JSON | Swappable with WhatsApp/Telegram |
+| Webhook | API Trigger | JSON | Bound to API contract |
+| IoT Sensor | Sensor Data | MQTT | Standardized numeric mapping |
+| Email Inbox | Comm. | MIME | IMAP protocol standardization |
+
+## Analysis
+
+### Mismatch or Gap
+- The current runtime heavily couples platform-specific details (e.g. tokens)
+  too early in the flow. A generic abstraction layer must exist between the
+  raw inbound payload and the internal logic queue.
+- Authentication boundaries for webhooks often require immediate responses
+  (e.g., HTTP 200 OK) which conflicts with asynchronous review cycles.
+
+### Unresolved Risks
+- **Signal Flooding:** Without a standardized rate-limiter at the edge of
+  the chain, the system is vulnerable to cascading failure from rapid external
+  signals (e.g., bot floods, sensor malfunctions).
+- **Format Drift:** External APIs or signal structures may change without
+  warning, breaking the entry chain if schema validation is not strictly
+  enforced at the boundary.
+
+### Next Single Recommended Action
+- Create a lightweight schema validation template for inbound payloads that
+  can be applied universally to all entry nodes before they are allowed onto
+  the primary AXIS-01 track.

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -37,6 +37,7 @@
 - 03_board-orchestration/runtime-spine/xuanling-calendar-time-window-adapter-contract-2026-04-19-v0-1.md: Time-window adapter contract.
 - 04_adapter-layer/activation_order.md: External tool onboarding sequence.
 - 04_adapter-layer/calendar-adapter.md: Calendar intake/sync logic.
+- 04_adapter-layer/line_entry_chain_spec.md: LINE entry node specification.
 - 04_adapter-layer/drive-adapter.md: Storage/snapshot/mirror logic.
 - 04_adapter-layer/gamma_entry_spec.md: Visual layer spec.
 - 04_adapter-layer/replit_relay_spec.md: Interaction relay spec.

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -14,6 +14,7 @@
 ## 1. Inventory by Family
 
 ### 1.1 Meta & Mother-Law (00)
+- EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md: Tool-agnostic entry chain specification.
 - 00_meta/user_identity_anchor.md: Primary identity alignment anchor.
 - 00_mother-law/README.md: Core governance entry.
 - 00_mother-law/existence-consistency-rule.md: Triple-condition (Exist/Being/Continue) consistency rule.

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -23,6 +23,7 @@
 - 05_topology/ (Triad & Consistency Rules)
 
 ### Group C — Operational Boards & Layers
+- EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
 - 01_native-board/ (Indices, Blockers, & Permissions)
 - 02_runtime-ops/ (Follow-up Tasks)
 - 03_board-orchestration/ (Binding & Intake Contracts)


### PR DESCRIPTION
This PR addresses Issue #39 by creating a specification for the first real-world entry point using LINE as an AXIS-01 entry node. The document includes a text-based flow diagram, credential requirements, constraint bounds (no execution/deployment), return-failure routing to AXIS-05, and mismatch analysis. Also included is indexing via `REPOSITORY_CORPUS_INDEX.md`.

---
*PR created automatically by Jules for task [16487373364363717179](https://jules.google.com/task/16487373364363717179) started by @chenchienheng*