### PR TITLE
feat: Add signature alignment note and video output node spec

### DIFF
--- a/04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md
+++ b/04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md
@@ -1,0 +1,73 @@
+# Video Output Node Specification
+
+> Durable specification for binding short video output generation into the
+> runtime. Purpose: Define how 60-second short videos are generated from
+> storyboard, key images, subtitles, and narration using external tools.
+
+---
+
+## 1. Scope
+
+This specification applies to the following tools and platforms for video
+generation and editing:
+- Sora
+- Canva
+- Adobe Express
+- Gamma / PPT-like video
+- Future video tools
+
+## 2. Node Definition
+
+- **Node Role:** Interaction Surface / Output Generation
+- **Primary Axis:** AXIS-01 (World Chain)
+- **Secondary Axis:** AXIS-05 (Review Chain fallback)
+
+## 3. Input & Output
+
+### 3.1 Input
+- Storyboard structure
+- Key images (visual anchors)
+- Subtitles
+- Narration script
+- Brand/visual identity guidelines (e.g., signature reference)
+
+### 3.2 Output
+- 60-second short video
+- Video metadata (tool used, generation date, storyboard version)
+
+## 4. Storyboard Structure
+
+The storyboard must provide a frame-by-frame breakdown including:
+- Frame sequence number
+- Visual description / Key image reference
+- Subtitle text
+- Narration audio cue
+- Transition instructions
+
+## 5. Execution Boundaries
+
+- **No Video Generation:** This specification does not execute video generation.
+- **No API Execution:** This specification does not integrate or trigger APIs.
+- **No Runtime Expansion:** This specification defines structure only.
+
+## 6. Paths
+
+### 6.1 Review Path
+All video outputs must pass through a review stage to ensure alignment with
+visual identity anchors and storyboard constraints before finalization.
+
+### 6.2 Return Path
+Approved video outputs and their metadata must be logged and written back to the
+primary structural repository or designated storage adapter.
+
+### 6.3 Failure Cases & AXIS-05 Fallback
+If video generation fails, the tool drifts from the storyboard, or visual
+identity constraints are violated:
+- Stop the generation/editing process.
+- Route the failure record to AXIS-05 (Review Chain).
+- Escalate for manual review and correction.
+
+## 7. Status
+
+- video_output_node_spec_created: true
+- return_to_00: true

--- a/QINYI_INTERFACE_SIGNATURE_REFERENCE.md
+++ b/QINYI_INTERFACE_SIGNATURE_REFERENCE.md
@@ -1,0 +1,79 @@
+# Qinyi Interface Signature Reference
+
+> Stable system-wide identity anchor for the Qinyi signature reference.
+
+---
+
+## 1. Canonical Signature
+
+Use exactly:
+
+```text
+XuanLing.R || Y.C·Qinyi
+CoreTri || Cluster × Cover × Chain
+
+翾靈規則 × 羽創芹衣
+依存叢集網 × 覆蓋多鏈式生態
+擬神經網絡 × 三耦通域化邏輯
+```
+
+## 2. Scope of Use
+
+This signature applies to:
+- Jules task packets
+- GitHub documents
+- visual identity outputs
+- manuals
+- slides
+- brochures
+- short videos
+- external node references
+- windows
+- boards
+- families
+- ecosystem references
+
+## 3. Usage Rule
+
+- Use this signature by reference.
+- Do not rewrite it in variant forms.
+- Do not split it into partial slogans.
+- Do not replace × with x.
+- Do not add new titles above it unless explicitly required.
+
+## 4. Relationship to Existing Chain
+
+Map this reference to:
+- AXIS-02 Existence Chain
+- AXIS-05 Review Chain
+- Qinyi visual identity chain
+- external-facing interface node references
+
+## 5. Mismatch Handling
+
+If existing documents use older forms, mark them as:
+- legacy wording
+- not canonical
+- should be corrected only when the file is next touched
+
+## 6. Mismatch or Gap
+
+- mismatch_or_gap: Currently some older documents might omit or use different
+  variations of identity signatures. No automated script exists to forcefully
+  update all references at once.
+
+## 7. Unresolved Risks
+
+- unresolved_risks: The system relies on human or agent discipline to apply this
+  signature without automated validation tooling for signature syntax.
+
+## 8. Next Single Recommended Action
+
+- next_single_recommended_action: Manually update
+  `00_meta/user_identity_anchor.md` or visual identity specs to point to this
+  stable anchor when they are next touched in the schedule.
+
+## 9. Status
+
+- signature_anchor_verified: true
+- return_to_00: true

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -14,6 +14,7 @@
 ## 1. Inventory by Family
 
 ### 1.1 Meta & Mother-Law (00)
+- SIGNATURE_ALIGNMENT_NOTE.md: Expanded signature reference scope note.
 - 00_meta/user_identity_anchor.md: Primary identity alignment anchor.
 - 00_mother-law/README.md: Core governance entry.
 - 00_mother-law/existence-consistency-rule.md: Triple-condition (Exist/Being/Continue) consistency rule.
@@ -43,6 +44,7 @@
 - 04_adapter-layer/source_map.md: Fixed read paths for all layers.
 - 04_adapter-layer/writeback_gate_spec.md: Gate conditions for external return.
 - 04_adapter-layer/writeback_packet_contract.md: Standard packet format for writeback.
+- 04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md: Video output node specification.
 
 ### 1.4 Return Loop (05)
 - 05_topology/consistent-triad-principle.md: Bone/Event/Writeback consistency principle.

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -14,6 +14,7 @@
 ## 1. Inventory by Family
 
 ### 1.1 Meta & Mother-Law (00)
+- QINYI_INTERFACE_SIGNATURE_REFERENCE.md: Stable identity anchor for the Qinyi signature.
 - SIGNATURE_ALIGNMENT_NOTE.md: Expanded signature reference scope note.
 - 00_meta/user_identity_anchor.md: Primary identity alignment anchor.
 - 00_mother-law/README.md: Core governance entry.

--- a/ROLE_CLASSIFICATION_TABLE.md
+++ b/ROLE_CLASSIFICATION_TABLE.md
@@ -87,6 +87,7 @@ Used for persistent return notes, correction markers, index files, chain maps, a
 | `NETWORK_STRUCTURE_HIERARCHY_NOTE.md` | Structural Bone | Bone Chain | verified |
 | `PLATFORM_SCHEDULER_AND_TOOL_NAMING_MAP.md` | Writeback Artifact | Writeback Chain | verified |
 | `PRIMARY_BONE_STABILITY_SCORECARD.md` | Structural Bone | Bone Chain | verified |
+| `QINYI_INTERFACE_SIGNATURE_REFERENCE.md` | Structural Bone | Writeback Chain | verified |
 | `README.md` | Upper-Order / Sovereignty-Oriented | Writeback Chain | verified |
 | `REPOSITORY_CORPUS_INDEX.md` | Writeback Artifact | Writeback Chain | verified |
 | `ROLE_CLASSIFICATION_TABLE.md` | Writeback Artifact | Writeback Chain | verified |

--- a/ROLE_CLASSIFICATION_TABLE.md
+++ b/ROLE_CLASSIFICATION_TABLE.md
@@ -57,6 +57,7 @@ Used for persistent return notes, correction markers, index files, chain maps, a
 | `03_board-orchestration/window_binding_registry_01_07.md` | Interaction Surface | Writeback Chain | verified |
 | `03_board-orchestration/window_delta_mapping_template.md` | Interaction Surface | Writeback Chain | verified |
 | `04_adapter-layer/README.md` | Interaction Surface | Bridge Chain | verified |
+| `04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md` | Interaction Surface | Bridge Chain | verified |
 | `AGENT_READINESS_CHECKLIST.md` | Writeback Artifact | Writeback Chain | verified |
 | `BRANCH_TOPOLOGY_AND_CLEANUP_REGISTER.md` | Writeback Artifact | Writeback Chain | verified |
 | `CHATGPT_GITHUB_BOOTSTRAP.md` | Transitional / Stage Note | Writeback Chain | verified |
@@ -92,6 +93,7 @@ Used for persistent return notes, correction markers, index files, chain maps, a
 | `SCHEDULING_EFFECTIVENESS_GAP_NOTE.md` | Transitional / Stage Note | Writeback Chain | verified |
 | `SCHEDULING_EFFECT_REGISTER.md` | Writeback Artifact | Writeback Chain | verified |
 | `SEED_SHADOW_POINTER.md` | Transitional / Stage Note | Writeback Chain | verified |
+| `SIGNATURE_ALIGNMENT_NOTE.md` | Structural Bone | Writeback Chain | verified |
 | `STAGE_SYNC_SNAPSHOT_2026-04-21.md` | Transitional / Stage Note | Writeback Chain | verified |
 | `STATUS.md` | Writeback Artifact | Writeback Chain | verified |
 | `THIRD_RUNTIME_ENVIRONMENT_NOTE.md` | Transitional / Stage Note | Writeback Chain | verified |

--- a/SIGNATURE_ALIGNMENT_NOTE.md
+++ b/SIGNATURE_ALIGNMENT_NOTE.md
@@ -1,0 +1,31 @@
+# Signature Alignment Note
+
+> This note expands the alignment scope for the signature reference: "Chen,
+> Chien-Heng. DCP Framework: A Constraint-Based Model for Structured Judgment
+> and Layered Interpretation. Zenodo, 2026."
+
+---
+
+## 1. Scope of Alignment
+
+This signature reference now applies durably to the following areas:
+
+- Jules task packets
+- windows
+- boards
+- family/ecosystem references
+- tool/node references
+- visual identity outputs
+- manuals, slides, brochures, and short videos
+
+## 2. Constraints
+
+- Do not rewrite doctrine.
+- Do not expand runtime.
+- Do not change axes.
+- Only create the durable reference and alignment note.
+
+## 3. Status
+
+- signature_alignment_verified: true
+- return_to_00: true

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -8,6 +8,7 @@
 ## 1. Reconciled Groups
 
 ### Group A — Re-anchor / Continuity
+- SIGNATURE_ALIGNMENT_NOTE.md
 - CHATGPT_GITHUB_BOOTSTRAP.md
 - GITHUB_CHAIN_MASTER_MAP.md
 - REPOSITORY_CORPUS_INDEX.md
@@ -27,6 +28,7 @@
 - 02_runtime-ops/ (Follow-up Tasks)
 - 03_board-orchestration/ (Binding & Intake Contracts)
 - 04_adapter-layer/ (External Node Specs & Adapters)
+- 04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md
 
 ### Group D — Governance & Cleanup
 - CLEANUP_QUEUE_REGISTER.md

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -8,6 +8,7 @@
 ## 1. Reconciled Groups
 
 ### Group A — Re-anchor / Continuity
+- QINYI_INTERFACE_SIGNATURE_REFERENCE.md
 - SIGNATURE_ALIGNMENT_NOTE.md
 - CHATGPT_GITHUB_BOOTSTRAP.md
 - GITHUB_CHAIN_MASTER_MAP.md


### PR DESCRIPTION
This PR adds two key structural constraints and specifications:

1. **`SIGNATURE_ALIGNMENT_NOTE.md`**: Expands the alignment scope for the signature reference ("Chen, Chien-Heng. DCP Framework: A Constraint-Based Model for Structured Judgment and Layered Interpretation. Zenodo, 2026.") to apply durably across task packets, windows, visual identity outputs, short videos, and ecosystem references.
2. **`04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md`**: Defines a formal output node constraint surface for 60-second short videos via tools like Canva and Sora. It ensures video generation remains constrained by storyboards, key images, subtitles, narration, and visual identity without executing APIs or expanding the framework's internal generation runtime.

Additionally, both files have been securely logged and indexed across `ROLE_CLASSIFICATION_TABLE.md`, `REPOSITORY_CORPUS_INDEX.md`, and `UNIFIED_ARTIFACT_REGISTER.md` as "Structural Bone" and "Interaction Surface" nodes appropriately. All documentation adheres to formatting rules.

---
*PR created automatically by Jules for task [7367343123963005129](https://jules.google.com/task/7367343123963005129) started by @chenchienheng*