### PR TITLE
[CoreTri] Tri-Coupling Review Hook Integration (Phase 1)

### DIFF
--- a/MULTI_CHAIN_DISPATCH_GOVERNANCE.md
+++ b/MULTI_CHAIN_DISPATCH_GOVERNANCE.md
@@ -57,6 +57,8 @@ The Review Hook ensures that outputs from any chain conform to the 80-character
 limit, naming conventions, and continuity requirements. It routes through the
 Review Chain Master Layer.
 
+- tri_coupling_state_check: optional
+
 ---
 
 ## 6. Return Path


### PR DESCRIPTION
Purpose:
Make TRI_COUPLING_STATE_SPEC.md observable within the dispatch system.

Changes:
- In MULTI_CHAIN_DISPATCH_GOVERNANCE.md under review_hook section, add:
  tri_coupling_state_check: optional

Constraints respected:
- no runtime expansion
- no API integration
- no new axes
- no doctrine rewrite
- minimal change only

---
*PR created automatically by Jules for task [13279811253134991373](https://jules.google.com/task/13279811253134991373) started by @chenchienheng*