### PR TITLE
[CoreTri] Add Redundant Load Reduction Spec

### DIFF
--- a/REDUNDANT_LOAD_REDUCTION_SPEC.md
+++ b/REDUNDANT_LOAD_REDUCTION_SPEC.md
@@ -1,0 +1,83 @@
+# [CoreTri] Redundant Load Reduction Spec
+
+> Purpose: Define how CoreTri reduces repeated context loading, duplicated
+> review work, and repeated task interpretation across ChatGPT, Jules, GitHub,
+> and external execution nodes.
+
+---
+
+## 1. Core Definition
+
+Redundant load occurs when multiple execution layers or nodes re-evaluate the
+same premise, reload identical contextual data without structural bounds, or
+re-review tasks that have already passed previous structural verification.
+This specification aims to establish methods to reduce this load without
+modifying doctrine, expanding runtime, or establishing new axes.
+
+## 2. Redundant Load Sources
+
+- **Context Re-loading**: Providing the entire repository context instead of
+  narrowing down to specific execution boundaries.
+- **Interpretation Drift**: Re-evaluating the definition of rules or boundaries
+  across different nodes.
+- **Duplicate Review**: Requesting human oversight for processes previously
+  verified by intermediate nodes.
+- **Execution Overlaps**: Parallel execution traces generating unmerged
+  artifacts that require repeated review.
+
+## 3. Delta-only Transmission Rule
+
+To prevent unbounded context loading, nodes must transmit and consume only the
+structural delta. This means:
+- Do not provide full context histories if an explicit anchor point exists.
+- Re-read existing specs to fetch constraints instead of rewriting them.
+- Any change packet should contain the difference from the canonical surface
+  rather than full-state duplication.
+
+## 4. Shared Coordinate Rule
+
+Nodes must utilize common structural maps (e.g., UNIFIED_ARTIFACT_REGISTER.md)
+to understand the terrain. Nodes must avoid generating distinct contextual
+orientations and instead read from these shared coordinates to instantly align
+their operational framework.
+
+## 5. Single Review Surface Rule
+
+A task should not undergo duplicated review processes if it has successfully
+passed the designated review layer. The structural review conducted by the
+coordinating node acts as the bridge; once confirmed structurally aligned,
+the output should proceed to final validation without redundant re-checks.
+
+## 6. Return-to-Register Rule
+
+To ensure that progress is preserved and redundant effort is minimized, all
+completed tasks and successfully reduced loads must document their final state
+in a designated registry. This allows future operations to refer to the
+registered state instead of re-calculating it.
+
+## 7. Failure Route: return_failed -> AXIS-05
+
+If a process fails to correctly reduce load, encounters an ambiguity in the
+delta, or fails to properly write back to the shared coordinate, the node must
+halt and direct the failure exactly via:
+`return_failed -> AXIS-05`
+
+## 8. mismatch_or_gap
+
+- Current registries track files but may not consistently track context
+  boundaries, leading to minor overlap.
+- Unmerged execution branches could still trigger redundant load during
+  topology sweeps.
+
+## 9. unresolved_risks
+
+- Over-reducing context could result in node amnesia, causing the node to lose
+  critical domain understanding.
+- Delta-only parsing relies on nodes having a perfect base state, which may
+  be misaligned.
+
+## 10. next_single_recommended_action
+
+Append this specification to `UNIFIED_ARTIFACT_REGISTER.md` and
+`REPOSITORY_CORPUS_INDEX.md` to ensure nodes integrate it into their core
+coordinate maps.

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -45,6 +45,7 @@
 
 ### 1.3 Sub-systems (02-04)
 - TASK_ORCHESTRATION_BRIDGE_SPEC.md: Define task orchestration bridge spec.
+-- REDUNDANT_LOAD_REDUCTION_SPEC.md: Specification on reducing redundant load.
 - INTERNAL_RELATIONAL_MESH_SPEC.md: Relational mesh strengthening internal
   carrying layer.
 - AXIS_TO_EXTERNAL_ABSORPTION_HANDOFF.md: Bridge document for external

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -30,6 +30,7 @@
 
 ### Group C — Operational Boards & Layers
 - TASK_ORCHESTRATION_BRIDGE_SPEC.md
+-- REDUNDANT_LOAD_REDUCTION_SPEC.md
 - EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
 - 01_native-board/ (Indices, Blockers, & Permissions)
 - 02_runtime-ops/ (Follow-up Tasks)


### PR DESCRIPTION
Closes #xxxx or fulfills user request to create REDUNDANT_LOAD_REDUCTION_SPEC.md. This PR establishes how CoreTri reduces redundant context loading, duplicated review work, and repeated task interpretation across nodes. It adds the specification adhering strictly to formatting and operational rules, without runtime expansion, new API integrations, or rewritten doctrine. The file has been registered in the main unified indices.

---
*PR created automatically by Jules for task [12160598594091314496](https://jules.google.com/task/12160598594091314496) started by @chenchienheng*