### PR TITLE
feat: Create Work OS Chain Integration Spec

### DIFF
--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -44,6 +44,7 @@
 - 01_runtime-spine/window_linking_logic_01_07.md: State-ladder transition rules.
 
 ### 1.3 Sub-systems (02-04)
+- WORK_OS_CHAIN_INTEGRATION_SPEC.md: Work OS chain integration specification.
 - TASK_ORCHESTRATION_BRIDGE_SPEC.md: Define task orchestration bridge spec.
 -- REDUNDANT_LOAD_REDUCTION_SPEC.md: Specification on reducing redundant load.
 - INTERNAL_RELATIONAL_MESH_SPEC.md: Relational mesh strengthening internal

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -29,6 +29,7 @@
 - 05_topology/ (Triad & Consistency Rules)
 
 ### Group C — Operational Boards & Layers
+- WORK_OS_CHAIN_INTEGRATION_SPEC.md
 - TASK_ORCHESTRATION_BRIDGE_SPEC.md
 -- REDUNDANT_LOAD_REDUCTION_SPEC.md
 - EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md

--- a/WORK_OS_CHAIN_INTEGRATION_SPEC.md
+++ b/WORK_OS_CHAIN_INTEGRATION_SPEC.md
@@ -1,0 +1,67 @@
+# [CoreTri] Work OS Chain Integration Spec
+
+> Defines how a single-domain Work OS (e.g., Hermes Agent) is integrated
+> as an execution chain node within the XuanLing multi-chain system.
+
+---
+
+## 1. Node Record Schema
+
+- **node_name:** Work OS (e.g., Hermes Agent)
+- **family_type:** execution / domain-specific orchestration
+- **owner_window:** Domain-specific window (e.g., Development/Task Routing)
+- **structural_role:** single-domain execution node
+- **input_type:** Task assignments, structured instructions, domain context
+- **output_type:** Task completion status, PRs, execution logs
+- **writeback_surface:** GitHub Issues, Pull Requests
+- **replacement_ready:** true
+- **failure_mode:** Halt execution, log trace, route to AXIS-05
+- **last_verified_time:** (To be updated on run)
+
+---
+
+## 2. External Ecosystem Absorption Properties
+
+- **primary_axis:** AXIS-01 (World Chain)
+- **secondary_axis:** AXIS-03 (Time Chain) / AXIS-05 (Review Chain)
+- **input:** Bounded task constraints, isolated codebase context, API boundaries
+- **output:** Code modifications, status updates, resource allocations
+- **execution_boundary:** Acts strictly as an execution node. Cannot perform
+  system building, UI design, or DB design. Operates strictly on logic and
+  structured task execution within bounded files.
+- **review_path:** Output passes through PR review by Human or embedded
+  Jules reviews before merging into the core bone.
+- **return_path:** PR submission and GitHub issue updates.
+- **fallback:** If execution drifts or exceeds constraints, halt and escalate
+  to AXIS-05 (Review Chain).
+
+---
+
+## 3. Integration Rules
+
+1. **No System Building:** The Work OS must not independently author new
+   architecture, redefine doctrine, or invent systemic mechanisms outside its
+   explicitly bounded task.
+2. **No UI / DB Design:** The node is restricted to logic, orchestration,
+   and structural updates, not visual presentation or data persistence modeling.
+3. **Traceable Actions:** Every meaningful state change initiated by the
+   Work OS must have a corresponding pull request or verifiable issue comment.
+4. **Immediate Fallback on Ambiguity:** If instructions are unclear or conflict
+   with established master laws, the Work OS must query the user or route the
+   flag to AXIS-05 rather than guessing.
+
+---
+
+## 4. mismatch_or_gap
+No existing framework formally restricted single-domain execution nodes from
+attempting UI or DB tasks previously; this spec introduces those hard boundaries
+to prevent scope creep.
+
+## 5. unresolved_risks
+If the Work OS receives instructions that mix logic updates with UI tweaks,
+the task parsing mechanism must successfully reject the out-of-bounds UI portion
+without failing the entire valid logic payload.
+
+## 6. next_single_recommended_action
+Ensure task prompt templates passed to the Work OS explicitly state the
+constraints: "NO SYSTEM BUILDING. NO UI/DB DESIGN. LOGIC/EXECUTION ONLY."


### PR DESCRIPTION
Creates the CoreTri Work OS Chain Integration Spec, defining how a single-domain Work OS (e.g. Hermes Agent) is integrated as an execution node within the XuanLing multi-chain system. The spec outlines strict execution boundaries (no system building, no UI/DB design) and registers the spec in the system indices.

---
*PR created automatically by Jules for task [12441406627587863735](https://jules.google.com/task/12441406627587863735) started by @chenchienheng*