### PR TITLE
Create Qinyi External Interface Submap v0.1

### DIFF
--- a/docs/qinyi/QINYI_EXTERNAL_INTERFACE_SUBMAP_v0.1.md
+++ b/docs/qinyi/QINYI_EXTERNAL_INTERFACE_SUBMAP_v0.1.md
@@ -75,6 +75,7 @@ The following elements must never be exposed through the Qinyi submap:
 ## 10. Next Integration Points
 
 The next steps for this submap involve binding the defined content routes to
-active publication channels, establishing automated identity verification hooks
-for the visual presentation layer, and integrating the management layer with
-future marketing pipelines.
+active publication channels, establishing future identity-consistency review
+hooks, subject to Mother Tree review and not implying current API/runtime
+automation, for the visual presentation layer, and integrating the management
+layer with future marketing pipelines.

--- a/docs/qinyi/QINYI_EXTERNAL_INTERFACE_SUBMAP_v0.1.md
+++ b/docs/qinyi/QINYI_EXTERNAL_INTERFACE_SUBMAP_v0.1.md
@@ -1,0 +1,80 @@
+# Qinyi External Interface Submap v0.1
+
+## 1. Purpose
+
+The purpose of this document is to establish Qinyi (羽創芹衣) as the first
+public-facing route on the XuanLing map. It provides a stabilized external
+interface submap for visual identity consistency, constraint teaching, gallery
+variants, mood and feeling notes, and future collaboration management.
+
+## 2. Position in XuanLing
+
+XuanLing remains the expanding full-map field; Qinyi is a stabilized external
+interface submap. Qinyi operates as the primary conduit for external-facing
+visual, cultural, and operational outputs, bridging the deep XuanLing core with
+the accessible public domain.
+
+## 3. Subsystem Boundary
+
+Qinyi's operational boundary encompasses only the defined public-facing
+artifacts. It is strictly scoped to govern the external presentation and
+interaction logic. It does not control, define, or alter the deep underlying
+XuanLing generative models, core relational physics, or unreleased systemic
+rules.
+
+## 4. Public Interface Layers
+
+The public interface layers include:
+- Visual Presentation Layer: Curated image galleries and identity consistency
+  anchors.
+- Didactic Layer: Constraint teaching materials and public-facing manuals.
+- Emotional Output Layer: Mood boards, feeling notes, and narrative summaries.
+- Management Layer: A structured interface for future marketing and external
+  collaboration.
+
+## 5. Content Routes
+
+Content is routed outward through Qinyi via specific authorized channels:
+- Visual Artifacts Route: Outputting character art and gallery variants.
+- Documentation Route: Releasing XuanLing notes and sanitized constraint
+  tutorials.
+- Engagement Route: Handling marketing assets and collaboration framing.
+
+## 6. Visual Invariant Rules
+
+Visual outputs flowing through this submap must adhere to established visual
+identity anchors (e.g., consistent facial structure, core temperament). The
+Qinyi signature reference must be consistently applied as the authoritative
+identity mark, ensuring all gallery variants remain anchored to the canonical
+persona without unauthorized drift.
+
+## 7. Expansion Paths
+
+Future expansion within the Qinyi submap will focus exclusively on broadening
+the public interface. This includes adding new gallery categories, expanding
+constraint teaching modules, and integrating specialized marketing endpoints,
+always strictly within the bounds of the external-facing role.
+
+## 8. GitHub / Zenodo Anchor Role
+
+This submap serves as the canonical reference within the GitHub repository and
+future Zenodo archives for all external-facing Qinyi outputs. It defines the
+stable structure for versioning visual assets, public documents, and
+collaboration histories, providing a clear structural boundary for external
+integration.
+
+## 9. Forbidden Exposure
+
+The following elements must never be exposed through the Qinyi submap:
+- Private human sources or references.
+- Personal relationship narratives.
+- Internal prompt chains and unredacted model execution logs.
+- Unreleased dependency-chain rules or raw core architecture.
+- Full XuanLing core system internals.
+
+## 10. Next Integration Points
+
+The next steps for this submap involve binding the defined content routes to
+active publication channels, establishing automated identity verification hooks
+for the visual presentation layer, and integrating the management layer with
+future marketing pipelines.


### PR DESCRIPTION
This PR introduces the `QINYI_EXTERNAL_INTERFACE_SUBMAP_v0.1.md` document under `docs/qinyi/`.

It defines Qinyi as the stabilized external interface submap for the XuanLing system, establishing constraints and visual identity rules for public-facing assets, while ensuring no deep system internals are exposed.

It meets all constraints including the 10 required sections and 80-character line limits.

---
*PR created automatically by Jules for task [15506741338843382092](https://jules.google.com/task/15506741338843382092) started by @chenchienheng*