### PR TITLE
Add XADF first round operation return log v0.1

### DIFF
--- a/docs/xuanling/XADF_FIRST_ROUND_OPERATION_RETURN_LOG_v0.1.md
+++ b/docs/xuanling/XADF_FIRST_ROUND_OPERATION_RETURN_LOG_v0.1.md
@@ -1,0 +1,364 @@
+# XADF First Round Operation Return Log
+
+## v0.1
+
+**System:** XuanLing All-Time Dependency Field  
+**Short code:** XADF  
+**Document type:** Operation return log  
+
+---
+
+## 0. Document Position
+
+This document records the first completed XADF round-chain operation.
+
+It is a return log, not a doctrine rewrite. It does not replace the Operation Manual, the Commander JD Specification, L0, mother-law, or Master Map v0.2.
+
+Purpose:
+
+```text
+Record what was learned after actually running a full round chain.
+Provide a clean source for future windows to recover the operating method without reading long chat history.
+Preserve the first practical evidence that round-based operation can reduce drift and token pressure.
+```
+
+---
+
+## 1. First-Round Summary
+
+The first completed XADF round-chain produced two clean tree seeds:
+
+```text
+PR #86 — XADF Operation Manual
+PR #87 — XADF Legion Commander JD Specification
+```
+
+The run demonstrated that XADF should not rely on long continuous chat context.
+Instead, it should operate through:
+
+```text
+Round System
+→ Task Card
+→ Packet when needed
+→ GitHub / document return anchor
+→ Final review link
+→ User decision
+```
+
+---
+
+## 2. Operating Pattern Change
+
+Before the run, the operating pattern was closer to:
+
+```text
+Ask / generate / revise / check / wait
+```
+
+After the run, the operating pattern became:
+
+```text
+Define round
+→ execute one slice
+→ review output
+→ create next task card
+→ write back to tree
+→ return for decision only when needed
+```
+
+This changes the assistant from a single-output helper into a bounded orchestrator that can manage middle rounds under explicit rules.
+
+---
+
+## 3. GitHub Commander Lessons
+
+GitHub works as the versioned artifact tree.
+
+Confirmed capabilities:
+
+```text
+create branch
+create file
+open PR
+comment on PR
+inspect PR state
+inspect changed files
+move files through tree / commit / ref operations
+validate document paths
+```
+
+Confirmed boundary:
+
+```text
+Do not merge automatically.
+Do not delete or rewrite root doctrine automatically.
+Do not treat GitHub as the whole ontology.
+```
+
+---
+
+## 4. Figure Package Lesson
+
+Binary figure upload required a user handoff during the first run.
+
+Lesson:
+
+```text
+If a connector cannot safely upload binary files, do not fake image files and do not commit broken paths.
+Create a package, request user handoff, then validate after upload.
+```
+
+---
+
+## 5. Review Packet Lesson
+
+Every round does not need an external file.
+
+New rule:
+
+```text
+Task card is mandatory.
+Round packet is produced only when cross-window handoff, external review, GitHub record, or final audit requires it.
+```
+
+Final review should provide:
+
+```text
+clickable link
+changed-file list
+boundary pass / fail
+decision options
+minimal judgment summary
+```
+
+---
+
+## 6. Confirmation Gate Learned
+
+Middle-round confirmation can be reduced by classifying actions into green, yellow, and red gates.
+
+### Green Gate — autonomous
+
+```text
+create non-destructive branch
+create companion document
+open PR
+leave PR comment
+check changed files
+check mergeability
+create task card
+create round packet when needed
+fix obvious path errors
+mark branch as subtree
+return-link to mother tree
+```
+
+### Yellow Gate — execute, then return packet
+
+```text
+formal report draft
+external content packet
+strategy judgment packet
+companion document PR
+figure package
+multi-tool projection
+merge-candidate PR
+```
+
+### Red Gate — stop for user decision
+
+```text
+merge PR
+delete file or branch
+close major issue
+rewrite L0 or mother-law
+change True Main strategy
+public release
+formal company conclusion
+external commitment
+turn Pending into Fact
+```
+
+---
+
+## 7. Forest Model
+
+GitHub should not be treated as a single tree in XADF operation.
+
+It should be treated as a forest:
+
+```text
+Mother Tree = True Main / XADF root return logic
+Branch Trees = commander-specific or window-specific documents and PRs
+Shared Layer = figures / task cards / review packets / source ledgers / routing manuals
+```
+
+Future main is formed by adhesion:
+
+```text
+old lineage
++
+new carrying topology
++
+commander branch trees
++
+shared reference layer
+→ True Main
+```
+
+---
+
+## 8. Mother / Child / Shared Tri-Coupling
+
+The run supports the following tri-coupling structure:
+
+```text
+Mother = invariant core, return calibration, merge logic
+Child = commander branches, window branches, task branches
+Shared = reusable evidence, figures, task cards, packets, routing references
+```
+
+Every branch should declare:
+
+```text
+domain
+scope
+boundary
+upstream reference
+downstream reference
+return path
+```
+
+---
+
+## 9. Token Compression Lesson
+
+Long-chain windows should not keep all work inside chat.
+
+Compression rule:
+
+```text
+Chat = current round summary and decision point
+Task Card = next-round continuation unit
+GitHub / Docs / PR = source anchor
+Packet = only when needed for handoff or audit
+Final Review = clickable link + decision options
+```
+
+This reduces token load and makes continuation possible when a conversation window becomes full.
+
+---
+
+## 10. Relation to Other Long-Chain Windows
+
+This log is intended to guide other long-chain windows such as:
+
+```text
+Strategy report long-chain window
+Qinyi external interface long-chain window
+XADF / True Main / GitHub Forest window
+```
+
+Each long-chain window should declare:
+
+```text
+Window_Name
+Window_Type
+Domain
+Boundary
+Return_Path
+```
+
+Each should use:
+
+```text
+Round System
+Task Card
+Confirmation Gate
+Return Link
+Final Review
+```
+
+---
+
+## 11. Current XADF Seed Set
+
+Current seed family:
+
+```text
+PR #86 — Operation Manual
+PR #87 — Legion Commander JD Specification
+PR #88 — First Round Operation Return Log
+```
+
+Interpretation:
+
+```text
+#86 = how the field operates
+#87 = who the commanders are and where their boundaries stop
+#88 = what was learned after actually running one chain
+```
+
+---
+
+## 12. Final Boundary
+
+This document does not:
+
+```text
+rewrite mother-law
+rewrite L0
+merge PRs
+activate schedules
+replace the Operation Manual
+replace the JD Specification
+turn XuanLing into runtime / API / database / automation platform
+```
+
+---
+
+## 13. Next Round Task Card
+
+```text
+Card_ID:
+XADF-R13-RETURN-LOG-REVIEW-v0.1
+
+Task Name:
+Review XADF First Round Operation Return Log PR
+
+Domain:
+GitHub Commander / XADF Forest / Operation Return Log
+
+Goal:
+Review the first operation return log PR and decide whether it should become the third XADF tree seed after #86 and #87.
+
+Input:
+1. PR containing docs/xuanling/XADF_FIRST_ROUND_OPERATION_RETURN_LOG_v0.1.md
+2. PR #86 Operation Manual
+3. PR #87 Commander JD Specification
+
+Deliverables:
+1. Changed-file check
+2. Boundary check
+3. Forest-model clarity check
+4. Token-compression rule check
+5. Confirmation-gate rule check
+6. Decision: READY_TO_REVIEW / REQUEST_CHANGES / HOLD_FOR_INDEX_REGISTRATION
+
+Negative Constraints:
+- Do not merge automatically.
+- Do not modify #82.
+- Do not modify #83.
+- Do not modify #86 or #87.
+- Do not reactivate schedules.
+
+Acceptance Criteria:
+- Changed files contain only the operation return log file.
+- The log records actual learning from a completed chain.
+- The log does not rewrite doctrine.
+- The forest model is clear.
+- The next step is a user final decision, not automatic merge.
+
+Recommended Next Step:
+Open PR and perform first self-review.
+```


### PR DESCRIPTION
## Summary

Adds the first XADF operation return log after completing a practical round-chain run.

## Scope

- Adds one new Markdown document under `docs/xuanling/`.
- Records what was learned after running the first XADF round chain.
- Captures:
  - round-based operation
  - task-card continuation
  - GitHub return anchors
  - confirmation-gate rules
  - forest model
  - token-compression rules
  - relation to other long-chain windows

## Boundary

This PR does **not**:

- rewrite mother-law or L0
- modify PR #86 or PR #87
- touch PR #82 cleanup
- fold into issue #83 Master Map v0.2
- reactivate schedules
- include private trust-core material
- frame XuanLing as runtime / API / database / automation platform

## Review focus

- Confirm changed files contain only the operation return log.
- Confirm the file records actual operational learning, not doctrine rewrite.
- Confirm forest model and token-compression rules are clear.
- Decide later whether index registration is needed as a separate PR.

Never merge automatically.