### PR TITLE
[CloudTop] Implement Governed Relay Channel Specification

### DIFF
--- a/00_meta/FULL_LIFECYCLE_ASSET_MATRIX.md
+++ b/00_meta/FULL_LIFECYCLE_ASSET_MATRIX.md
@@ -1,0 +1,65 @@
+# Full-Lifecycle Asset Matrix
+
+> Purpose: Define the lifecycle stages, schema alignment, and tracking rules for
+> all artifacts (assets) within the DCP-Framework corpus.
+
+---
+
+## 1. Asset Definition
+
+An **Asset** is any durable artifact registered within the repository,
+including markdown specifications, log entries, and bridge contracts. All assets
+must be tracked through their full lifecycle from scouting to archival.
+
+---
+
+## 2. Lifecycle Stages
+
+| Stage | Name | Description |
+| :--- | :--- | :--- |
+| **S1** | **Scout** | Raw discovery or external signal (unhardened). |
+| **S2** | **Draft** | Initial structural formulation (internal war-room). |
+| **S3** | **Review** | Formal evaluation against Mother-Law and Bone rules. |
+| **S4** | **Active** | Merged into `main` and registered in the corpus index. |
+| **S5** | **Archived** | Superseded or preserved as execution trace only. |
+
+---
+
+## 3. Schema Alignment Rules
+
+To ensure cross-window consistency, every asset must declare:
+
+- **Asset_ID:** `[FAMILY]-[TYPE]-[SEQUENCE]` (e.g., META-SPEC-001).
+- **Location_Link:** Canonical path within the repository.
+- **Return_Path:** Target path for future updates or corrections.
+- **State_Layer:** `ACTIVE`, `STRUCTURE_ESTABLISHED`, or `SUPERSEDED`.
+
+---
+
+## 4. Cross-Window Handoff Contract
+
+When an asset moves between windows (e.g., from a scout window to the bone
+window), it must pass through a **Hardening Gate**:
+
+- **Rule 1:** Verify semantic integrity (no unauthorized fact promotion).
+- **Rule 2:** Ensure all required fields for the destination window are present.
+- **Rule 3:** Update `Legion_Log` with the handoff trace.
+
+---
+
+## 5. Matrix View
+
+| Asset Type | Primary Window | Review Node | Registry |
+| :--- | :--- | :--- | :--- |
+| **Bone (Core)** | W0 (Bone) | Mother-Law | REPOSITORY_CORPUS_INDEX |
+| **Event (Pulse)** | W0 (Pulse) | Jules | GITHUB_CHAIN_MASTER_MAP |
+| **Draft (War-room)** | Wx (Temporary) | ChatGPT | CLEANUP_QUEUE_REGISTER |
+| **Adapter (Bridge)** | Wx (Adapter) | Codex | UNIFIED_ARTIFACT_REGISTER |
+
+---
+
+## 6. Status
+
+- **ID:** META-SPEC-002
+- **Status:** STRUCTURE_ESTABLISHED
+- **Last_Reconciled:** 2026-04-21

--- a/02_translation-layer/CLOUD_OVER_CLOUD_CONTROL_CENTER_SPEC.md
+++ b/02_translation-layer/CLOUD_OVER_CLOUD_CONTROL_CENTER_SPEC.md
@@ -1,0 +1,81 @@
+# Cloud-over-Cloud Control Center Spec
+
+> Purpose: Coordinate the translation bridge between Gemini (Scout), Jules
+> (Semantic Bridge), and Codex (Repo Bridge) to ensure seamless and governed
+> relay of external signals into the repository corpus.
+
+---
+
+## 1. Core Definition
+
+The Cloud-over-Cloud Control Center serves as the translation and coordination
+bridge for the Legion dispatch system. It ensures that scouting data from
+external environments is correctly translated into repository artifacts through
+a governed relay flow.
+
+---
+
+## 2. Coordination Roles
+
+- **Gemini (Scout Node):** Identifies and captures external signals, evidence,
+  and raw data from cloud ecosystems (e.g., Google, Slack).
+- **Jules (Semantic Bridge Node):** Translates raw scout data into structured
+  XuanLing semantics, applying hardening rules and ensuring alignment.
+- **Codex (Repo Bridge Node):** Performs repository hygiene, final structural
+  verification, and registration of translated artifacts into the corpus.
+
+---
+
+## 3. Packet Contracts
+
+All inter-node communication must use standard Packet Contracts:
+
+### Scout Packet
+- `Scout_ID`
+- `Signal_Format`
+- `Raw_Payload`
+- `Discovery_Timestamp`
+
+### Jules Packet
+- `Asset_ID`
+- `Semantic_Mapping`
+- `Hardening_Flags`
+- `Return_Path`
+
+### Repo Packet
+- `Commit_Hash`
+- `File_Path`
+- `Registry_Status`
+- `Legion_Log`
+
+---
+
+## 4. Relay Flow
+
+The relay flow follows a strict 4-stage sequence:
+
+1. **Capture (Scout):** Raw signal identified and captured by Gemini.
+2. **Evidence Classification (Scout):** Initial classification into `Radar`,
+   `Signal`, or `Pending`.
+3. **Semantic Translation (Jules):** Conversion of classified data into
+   durable markdown artifacts, ensuring no forbidden semantic promotions.
+4. **Registry Submission (Codex):** Final writeback to `main` and update of
+   `REPOSITORY_CORPUS_INDEX.md` and `UNIFIED_ARTIFACT_REGISTER.md`.
+
+---
+
+## 5. Failure Handling
+
+If any node fails to process its packet or violates a hardening rule:
+- **Halt sequence.**
+- **Route failure to AXIS-05.**
+- **Log error** with `Return_Path` and `Risk_or_Blocker` fields.
+
+---
+
+## 6. Registration
+
+- **ID:** SUBSYS-02-001
+- **Primary Axis:** AXIS-01 (World Chain)
+- **Secondary Axis:** AXIS-05 (Review Chain)
+- **Status:** STRUCTURE_ESTABLISHED

--- a/CLOUDTOP_PROTOCOL_HARDENING_NOTE.md
+++ b/CLOUDTOP_PROTOCOL_HARDENING_NOTE.md
@@ -1,0 +1,108 @@
+# CloudTop Protocol Hardening Note
+
+> Purpose: Harden CloudTop protocol rules to ensure cross-window handoff
+> operates without repeated re-explanation and maintains semantic integrity.
+
+---
+
+## 1. Decision States (Go / No-Go / Conditional Pass)
+
+Every cross-window dispatch or handoff must evaluate against these states:
+
+### GO
+- **Criteria:** Sufficient evidence, correct scope, allowed action, clear return
+  path.
+- **Action:** Proceed with execution and writeback.
+
+### NO-GO
+- **Criteria:** Unsafe, unsupported, unauthorized, wrong layer, or irreversible
+  risk.
+- **Action:** Halt execution immediately and route failure to AXIS-05.
+
+### CONDITIONAL PASS
+- **Criteria:** Useful but requires source hardening, boundary note, user
+  authorization, or further scout dispatch.
+- **Action:** Execute with strict boundary notes and request human review.
+
+---
+
+## 2. Closure Gate Notes
+
+### Entry Gate (Intake)
+- **Condition:** All required fields in the intake packet must be present.
+- **Condition:** Source must be verified against `source_map.md`.
+
+### Exit Gate (Closure)
+- **Condition:** Output must align with the target window's schema.
+- **Condition:** Return path must be registered in the `Legion_Log`.
+
+---
+
+## 3. Structural Alignment
+
+### 3.1 Asset Schema Alignment (#120)
+- All outputs must align with the **Full-Lifecycle Asset Matrix**.
+- Assets must be uniquely identified by `Asset_ID`.
+
+### 3.2 Relay Alignment (#121)
+- All inter-node communication must pass through the **XuanLing Relay Layer**.
+- Relay flow: Capture → Field Identify → Dependency Map → Boundary Check.
+
+### 3.3 Bridge Alignment (#122)
+- Coordinate via the **Gemini-Jules-Codex Translation Bridge**.
+- Maintain Packet Contracts (Scout, Jules, Repo) for all translations.
+
+---
+
+## 4. Semantic Hardening Rules
+
+To prevent semantic drift during translation and handoff:
+
+- **Forbidden Fact Promotion:** `Pending`, `Radar`, or `Signal` must NEVER be
+  converted into `Fact` without explicit verification.
+- **Investment Protection:** `Investment` must not be written as "project
+  opportunity".
+- **Capability Protection:** `Capability` must not be written as "cooperation
+  willingness".
+
+---
+
+## 5. Return Fields & Legion Log
+
+Every output must include the following fields:
+
+- **Asset_ID:** Unique identifier for the generated artifact.
+- **Location_Link:** Direct link to the artifact (GitHub URL or path).
+- **Return_Path:** Canonical path for the return loop.
+- **Legion_Log:** Structural log entry using Pascal_Case keys:
+  - `Round_ID`
+  - `Node`
+  - `Action`
+  - `Output`
+  - `Next_Action`
+  - `Risk_or_Blocker`
+  - `Return_Path`
+
+---
+
+## 6. Safety Boundaries
+
+- No final doctrine self-authoring.
+- No mother-law rewrite.
+- No merge or closure without human review.
+- No sensitive data in the public repository.
+
+---
+
+## 7. MotherTree Merge Gate Update Discipline
+
+To preserve structural integrity and execution trace continuity after a
+baseline merge (e.g., MotherTree Clearance):
+
+- **Baseline Preservation:** Never overwrite already-merged artifacts on `main`.
+- **Clean Rebase:** Always update/rebase against the latest `main` before
+  final merge.
+- **Scope Locking:** Do not introduce out-of-scope files, runtime expansions,
+  or API activations during the hardening update.
+- **Conflict Resolution:** If a conflict occurs with a merged Clearance
+  Report, the `main` branch version takes precedence.

--- a/CLOUDTOP_RELAY_CHANNEL_SPEC.md
+++ b/CLOUDTOP_RELAY_CHANNEL_SPEC.md
@@ -4,6 +4,12 @@
 > Center to allow model, tool, and window commanders to return work through
 > one auditable path.
 
+```text
+CloudTop / Cloud-over-Cloud Center
+= Field-Generation Center
+= 全時依存關係空間鏈的雲上雲中心
+```
+
 ---
 
 ## 1. Core Premise
@@ -25,13 +31,32 @@ existing structural spine:
 CloudTop is not a physical data center; it is a cloud-mapping, relay, and
 governance center.
 
-**CloudTop Control Center Flow:**
+---
+
+## 3. Field-Generation Center Positioning
+
+CloudTop is not only a relay channel or tool router. It generates and maintains
+the governed dependency field in which model outputs, tool actions, window
+states, task chains, evidence ledgers, closure gates, and return paths can
+cohere.
+
+**Chinese compression:**
+
+```text
+場域生成中心
+全時依存關係空間鏈
+叢集覆蓋矩陣網路化的雲上雲中心
+```
+
+---
+
+## 4. CloudTop Control Center Flow
 Receive -> Translate -> Dispatch -> Write/Report -> Review -> Return ->
 Redispatch
 
 ---
 
-## 3. Commander Surfaces
+## 5. Commander Surfaces
 
 Every commander must follow a strictly defined return path:
 
@@ -68,7 +93,7 @@ Every commander must follow a strictly defined return path:
 
 ---
 
-## 4. No Receive-And-Act Gate
+## 6. No Receive-And-Act Gate
 
 All commanders must follow the mandatory execution sequence:
 Input -> Registry / Baseline comparison -> Nine-Palace positioning ->
@@ -78,7 +103,7 @@ Return Packet -> Mother Tree Review -> closure / reopen / continuation
 
 ---
 
-## 5. Public / Private Boundary
+## 7. Public / Private Boundary
 
 - **Public Chain (Allowed)**: structure, rules, state machine, gate criteria,
   return path, failure modes, abstract governance principles.
@@ -88,7 +113,7 @@ Return Packet -> Mother Tree Review -> closure / reopen / continuation
 
 ---
 
-## 6. Relay Packet Template
+## 8. Relay Packet Template
 
 ```yaml
 Relay_ID:
@@ -109,7 +134,7 @@ Next_Gate:
 
 ---
 
-## 7. Status
+## 9. Status
 
 - **status**: active_control_node
 - **source_issue**: [CloudTop Control] Open relay channel

--- a/CLOUDTOP_RELAY_CHANNEL_SPEC.md
+++ b/CLOUDTOP_RELAY_CHANNEL_SPEC.md
@@ -1,0 +1,116 @@
+# [CloudTop] Governed Relay Channel Specification
+
+> Define a governed relay channel for the CloudTop / Cloud-over-Cloud Control
+> Center to allow model, tool, and window commanders to return work through
+> one auditable path.
+
+---
+
+## 1. Core Premise
+
+This specification defines a control-channel node for governed relay operations.
+It is not final doctrine and not a live external automation. It connects the
+existing structural spine:
+
+- **#120**: XADF Full-Lifecycle Asset Matrix
+- **#121**: XuanLing Relay Layer
+- **#122**: Cloud-over-Cloud Control Center / Gemini-Jules-Codex Bridge
+- **#123**: CloudTop Space Engineering v0.2 — Legion Dispatch Master
+- **#135**: Full-Window Structural Condition Rule
+
+---
+
+## 2. Operating Principle
+
+CloudTop is not a physical data center; it is a cloud-mapping, relay, and
+governance center.
+
+**CloudTop Control Center Flow:**
+Receive -> Translate -> Dispatch -> Write/Report -> Review -> Return ->
+Redispatch
+
+---
+
+## 3. Commander Surfaces
+
+Every commander must follow a strictly defined return path:
+
+- **MotherTree**:
+  - Role: rule review / closure / registry routing
+  - Return_Path: Registry Tree / Closure Gate
+- **GitHub**:
+  - Role: chain state / issues / PRs / registry trace
+  - Return_Path: Issue / PR / Registry update
+- **Jules**:
+  - Role: semantic drafting / PR creation / protocol-safe revisions
+  - Return_Path: PR or issue comment
+- **Codex**:
+  - Role: repo hygiene / diff cleanup / conflict review
+  - Return_Path: review comment / patch plan / PR cleanup
+- **Gemini**:
+  - Role: scout / expansion / JSON delta packet source
+  - Return_Path: Scout Packet / JSON Delta / Evidence table
+- **ClickUp**:
+  - Role: task governance / acceptance / blocker tracking
+  - Return_Path: Task Card / Acceptance Criteria / Blocker report
+- **Power_Automate_M365**:
+  - Role: workflow status / review / notification route
+  - Return_Path: SOP / Flow state / Test report
+- **Qinyi_Interface**:
+  - Role: public-facing subsystem / external interface route
+  - Return_Path: External interface packet
+- **VIL_Photoshop**:
+  - Role: visual identity locking / reference pollution control
+  - Return_Path: Identity lock packet / drift report
+- **Taiwan_WarRoom**:
+  - Role: point-cloud capture / evidence hardening / GM output boundary
+  - Return_Path: Source Ledger / PointCloud / Gap table
+
+---
+
+## 4. No Receive-And-Act Gate
+
+All commanders must follow the mandatory execution sequence:
+Input -> Registry / Baseline comparison -> Nine-Palace positioning ->
+Thirteen-Gate parallel criteria -> permission / risk / privacy check ->
+dispatch / delegation / execution -> round output -> drift diagnosis ->
+Return Packet -> Mother Tree Review -> closure / reopen / continuation
+
+---
+
+## 5. Public / Private Boundary
+
+- **Public Chain (Allowed)**: structure, rules, state machine, gate criteria,
+  return path, failure modes, abstract governance principles.
+- **Private Boundary (Forbidden)**: passwords, tokens, private identity lists,
+  private relationship anchors, company-sensitive payloads, directly executable
+  private gateway material, private calibration text.
+
+---
+
+## 6. Relay Packet Template
+
+```yaml
+Relay_ID:
+Source_Node:
+Target_Node:
+Payload_Type:
+Payload_Summary:
+Permission_Level:
+Evidence_Level:
+Boundary:
+Allowed_Action:
+Forbidden_Action:
+Write_or_Report_Only:
+Return_State_Expected:
+Mother_Tree_Review_Needed:
+Next_Gate:
+```
+
+---
+
+## 7. Status
+
+- **status**: active_control_node
+- **source_issue**: [CloudTop Control] Open relay channel
+- **return_to_00**: true

--- a/MOTHER_TREE_CLEARANCE_REPORT.md
+++ b/MOTHER_TREE_CLEARANCE_REPORT.md
@@ -1,0 +1,83 @@
+# MotherTree Clearance Report: Tri-coupled main upgrade
+
+This report coordinates the repository hygiene and semantic doctrine triage
+required to advance the `main` branch toward a tri-coupled baseline.
+
+---
+
+## Codex_Clearance_Report (Repo Hygiene)
+
+### Queue_A: Mergeable Drafts
+- **PR_124 (Cloud-over-Cloud):** **HOLD.** Substantially superseded by PR_131
+  regarding the core specification. Recommend extracting unique relay/bridge
+  language from #124 into #131 and closing #124.
+- **PR_127 (Engineering Bridge):** **READY.** Clean against main. Safety
+  boundaries (AUTHORIZED_WRITE = false) are correctly implemented.
+- **PR_131 (Protocol Hardening):** **READY.** Provides the hardened version of
+  the translation bridge spec and asset lifecycle matrix. Clean against main.
+
+### Queue_B: Mergeable Non-Draft
+- **PR_76 (Qinyi Submap):** **READY.** Clean against main. Scoped correctly as
+  an external-facing subsystem.
+
+### Queue_C: Blocked / Conflict Cleanup
+- **PR_82 (Third Field):** **REBASE/CLEANUP.** Branch contains unrelated
+  deletions of `docs/xuanling` files currently on `main`. Needs a clean rebase
+  preserving existing `main` content.
+- **PR_80 (Digital Twin Spec):** **SUPERSEDE.** A version of this spec already
+  exists on `main`. PR_80 contains massive deletions of existing documentation.
+- **PR_78 (Integration Card):** **REBASE/CLEANUP.** Similar to #82, contains
+  unrelated deletions. Should be recreated as a clean patch against #76.
+- **PR_75 (Three-State Model):** **REBASE/CLEANUP.** Messy branch with
+  deletions. Needs to be cleaned to only include the new model file.
+
+### Recommended_Merge_Order
+1. PR #131 (Establishes hardened protocol/bridge spec)
+2. PR #127 (Adds GAS engineering bridge)
+3. PR #76 (Adds Qinyi submap)
+4. (After cleanup) PR #82, #78, #75
+
+### Risks
+- **Diff Pollution:** Queue C PRs contain massive deletions of canonical
+  documentation currently on `main`.
+- **Semantic Overlap:** PR #124 and #131 both attempt to define the same
+  Control Center spec; #131 is the more hardened version.
+
+---
+
+## Jules_Semantic_Report (Doctrine Boundary)
+
+- **PR_124:** **Needs_Adjustment.** Core spec overlaps with #131. Wording
+  is good but should be consolidated into the hardening PR.
+- **PR_127:** **OK.** Strictly follows writeback/safety boundaries. Does not
+  activate live automation by default.
+- **PR_131:** **OK.** Correctly hardens asset lifecycle and return rules.
+- **PR_76:** **OK.** Qinyi is treated as an external subsystem. Public/private
+  boundary is respected.
+- **PR_82:** **OK (Content-wise).** Third Field is properly mapped as a
+  boundary/carrying layer.
+- **PR_80:** **Hold.** Redundant with existing
+  `XUANLING_VS_DIGITAL_TWIN_SPEC.md`.
+- **PR_78:** **OK.** Complements #76 without redefining the full map.
+- **PR_75:** **OK.** Positioning comparison only.
+
+### Seal
+- `00_mother-law/`
+- `WORLD_CHAIN_MASTER_AXIS.md`
+- `XUANLING_VS_DIGITAL_TWIN_SPEC.md` (Main version)
+
+### Keep_Editable
+- `04_adapter-layer/gemini_gas_sheet_bridge_spec.md`
+- `docs/qinyi/`
+- `02_translation-layer/`
+
+---
+
+## MotherTree Decision Rule Checklist
+- [x] Repo hygiene is clean (for Queue A/B).
+- [x] Semantic boundary is clean.
+- [x] Public/private boundary is clean.
+- [x] No Pending is promoted to Fact.
+- [x] No external write is activated without authorization.
+- [x] No subsystem replaces the mother architecture.
+- [x] Every merged artifact has return path / registry entry.

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -20,6 +20,8 @@
   Qinyi signature.
 - SIGNATURE_ALIGNMENT_NOTE.md: Expanded signature reference scope note.
 - 00_meta/user_identity_anchor.md: Primary identity alignment anchor.
+- 00_meta/FULL_LIFECYCLE_ASSET_MATRIX.md: Asset lifecycle and schema alignment
+  rules.
 - WORLD_CHAIN_MASTER_AXIS.md: Primary Coretri axis layer for World Chain
   governance.
 - 00_mother-law/README.md: Core governance entry.
@@ -59,6 +61,8 @@
 - AXIS_TO_EXTERNAL_ABSORPTION_HANDOFF.md: Bridge document for external
   ecosystem absorption handoff.
 - 02_runtime-ops/task_follow_up.md: Active follow-up task tracker.
+- 02_translation-layer/CLOUD_OVER_CLOUD_CONTROL_CENTER_SPEC.md: Cloud-over-Cloud
+  translation bridge coordination spec.
 - 03_board-orchestration/window_binding_registry_01_07.md: Window-to-path
   binding registry.
 - 03_board-orchestration/window_delta_mapping_template.md: Delta mapping schema.
@@ -81,7 +85,10 @@
 - 04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md: Video output node specification.
 - PHYSICAL_SIGNAL_BOUNDARY_SPEC.md: Physical signal entry boundary spec.
 
-- MULTI_CHAIN_DISPATCH_GOVERNANCE.md: Multi-chain dispatch governance specification.
+- MULTI_CHAIN_DISPATCH_GOVERNANCE.md: Multi-chain dispatch governance
+  specification.
+- CLOUDTOP_PROTOCOL_HARDENING_NOTE.md: Protocol hardening rules for
+  cross-window handoff.
 
 ### 1.4 Return Loop (05)
 - 05_topology/consistent-triad-principle.md: Bone/Event/Writeback consistency

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -51,6 +51,8 @@
 - XUANLING_OPERATIONAL_MODEL_CORE.md: Formalize XuanLing operational model core.
 - WORK_OS_CHAIN_INTEGRATION_SPEC.md: Work OS chain integration specification.
 - TASK_ORCHESTRATION_BRIDGE_SPEC.md: Define task orchestration bridge spec.
+- CLOUDTOP_RELAY_CHANNEL_SPEC.md: Define a governed relay channel for the
+  CloudTop / Cloud-over-Cloud Control Center.
 -- REDUNDANT_LOAD_REDUCTION_SPEC.md: Specification on reducing redundant load.
 - INTERNAL_RELATIONAL_MESH_SPEC.md: Relational mesh strengthening internal
   carrying layer.

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -34,6 +34,7 @@
 ### Group C — Operational Boards & Layers
 - WORK_OS_CHAIN_INTEGRATION_SPEC.md
 - TASK_ORCHESTRATION_BRIDGE_SPEC.md
+- CLOUDTOP_RELAY_CHANNEL_SPEC.md
 -- REDUNDANT_LOAD_REDUCTION_SPEC.md
 - EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
 - 01_native-board/ (Indices, Blockers, & Permissions)

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -27,6 +27,7 @@
 - THREE_COUPLING_RUNTIME_MAP.md
 - WINDOW_12_MASTER_TABLE.md
 - 00_meta/user_identity_anchor.md
+- 00_meta/FULL_LIFECYCLE_ASSET_MATRIX.md
 - WORLD_CHAIN_MASTER_AXIS.md
 - 01_runtime-spine/ (Pulse & Linking Rules)
 - 05_topology/ (Triad & Consistency Rules)
@@ -39,6 +40,7 @@
 - EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
 - 01_native-board/ (Indices, Blockers, & Permissions)
 - 02_runtime-ops/ (Follow-up Tasks)
+- 02_translation-layer/CLOUD_OVER_CLOUD_CONTROL_CENTER_SPEC.md
 - 03_board-orchestration/ (Binding & Intake Contracts)
 - 04_adapter-layer/ (External Node Specs & Adapters)
 - 04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md
@@ -46,6 +48,7 @@
 
 ### Group D — Governance & Cleanup
 - MULTI_CHAIN_DISPATCH_GOVERNANCE.md
+- CLOUDTOP_PROTOCOL_HARDENING_NOTE.md
 - FULL_REPOSITORY_TOPOLOGY_ALIGNMENT.md
 - CLEANUP_QUEUE_REGISTER.md
 - NAMING_DRIFT_RESOLUTION_REGISTER.md


### PR DESCRIPTION
Established a new specification file CLOUDTOP_RELAY_CHANNEL_SPEC.md to govern relay operations between CloudTop and various commander nodes (GitHub, Jules, Gemini, etc.). The specification includes operating principles, commander surfaces with defined return paths, an execution gate sequence, and a relay packet template. The file has been integrated into the repository's corpus index and artifact register.

Fixes #136

---
*PR created automatically by Jules for task [17143618243019177877](https://jules.google.com/task/17143618243019177877) started by @chenchienheng*