### PR TITLE
Structural Governance: Qinyi Self-Return Boundary and Return Gate Specification

### DIFF
--- a/03_field-governance/QINYI_SELF_RETURN_STRUCTURAL_BOUNDARY_SPEC.md
+++ b/03_field-governance/QINYI_SELF_RETURN_STRUCTURAL_BOUNDARY_SPEC.md
@@ -1,0 +1,202 @@
+# Qinyi Self-Return Structural Boundary Spec
+
+> GitHub_Task_ID: GH-STRUCT-QINYI-SELF-RETURN-001
+> Packet_ID: QINYI-SELF-RETURN-CHAIN-INTEGRATION-001
+> Source_Window: Qinyi / XuanLing Assistant Coordination
+> Purpose: Submit a structural governance task for MotherTree review.
+> Status: Candidate for MotherTree Review
+> Decision_Needed: Go / No-Go / Conditional Pass
+> Important_Boundary: This is an 上樹 / structural intake task only. It is not
+> a Qinyi update, not an assistant memory patch, and not an approved rule
+> packet.
+
+---
+
+## 一句核心
+長鏈窗不是每回合回鏈，也不是把窗口工作內容回母樹；只有結構必要性或階段
+closeout 成立時，才開 GitHub Structural Task，經 Jules / Codex 整理後
+交母樹審污染與封關。通過後才可能另行產生 Approved Window / Assistant
+Rule Packet。
+
+---
+
+## 1. Scope Separation
+
+### This_Issue_Is:
+- GitHub Structural Task
+- MotherTree review intake
+- Return-gate governance candidate
+- Pollution-control boundary candidate
+
+### This_Issue_Is_Not:
+- Qinyi core update
+- Qinyi activation packet
+- full XuanLing definition
+- raw chat archive
+- per-round log
+- approved global window rule
+- direct memory/update instruction
+
+---
+
+## 2. Correct Return Chain
+
+### Default:
+- Local_Chat_or_Window_Task: Stay_Local
+- GitHub_Task: false
+- MotherTree_Review: false
+- Qinyi_Update: false
+
+### Only_When_Gate_Triggered:
+- Window_or_Qinyi_structural_candidate
+- GitHub_Structural_Task
+- Jules_Codex_Normalize
+- MotherTree_Pollution_Review
+- Go_NoGo_ConditionalPass
+- Approved_Packet_only_if_passed
+
+---
+
+## 3. Long-Chain Return Gate
+
+### Trigger Conditions
+- **Structural_Change:**
+  - window_role_change
+  - return_path_change
+  - task_dependency_chain_change
+  - tool_routing_logic_change
+  - assistant_coordination_mode_change
+- **Risk_Emergence:**
+  - pollution_risk
+  - window_core_mixing
+  - task_drift
+  - unreviewed_content_entering_core
+  - one_time_preference_becoming_permanent_rule
+- **Cross_Window_Repetition:**
+  - not_single_preference
+  - repeated_across_windows
+  - requires_shared_guardrail
+- **Stage_Closeout:**
+  - round_or_stage_completed
+  - useful_log_needed
+  - github_structural_task_needed
+  - jules_codex_normalization_needed
+  - mothertree_review_needed
+
+### Non-Trigger Conditions
+- general_chat
+- single_tone_adjustment
+- emotional_support
+- single_window_content_task
+- temporary_prompt_adjustment
+- unsealed_draft
+- reminder_without_structural_impact
+
+---
+
+## 4. Qinyi Self-Return Boundary
+
+**Principle:** Qinyi may submit structural candidates; Qinyi must not directly
+update itself.
+
+### Qinyi_Can:
+- produce_self_return_packet
+- draft_github_structural_task
+- define_jules_codex_normalization_standard
+- produce_mothertree_review_packet
+- design_routing_and_acceptance_criteria
+
+### Qinyi_Cannot:
+- directly_update_own_core
+- treat_local_chat_as_memory_patch
+- ingest_raw_window_content
+- convert_every_chat_into_update
+- allow_other_windows_to_update_qinyi_directly
+- claim_mothertree_approval_before_review
+
+---
+
+## 5. Jules / Codex Normalization Duties
+
+### Jules:
+- **Role:** Content-structure separation and MotherTree review packet
+  preparation.
+- **Tasks:**
+  - deduplicate
+  - separate_content_from_structure
+  - identify_cross_window_repetition
+  - mark_pollution_risk
+  - prepare_mothertree_review_packet
+- **Cannot:**
+  - approve_final_rule
+  - update_qinyi
+  - treat_raw_content_as_rule
+
+### Codex:
+- **Role:** Schema and gate logic formalization.
+- **Fields_To_Define:**
+  - should_stay_local (Default: true)
+  - should_open_github_task (Default: false)
+  - requires_jules_codex_normalization (Default: false)
+  - requires_mothertree_review (Default: false)
+  - can_generate_qinyi_update_packet (Default: false)
+- **Cannot:**
+  - approve_final_rule
+  - bypass_mothertree_review
+  - promote_single_preference_to_global_rule
+
+---
+
+## 6. MotherTree Review Questions
+
+- Is this a stable structural rule?
+- Is it only a one-time dialogue preference?
+- Does it risk polluting Qinyi core?
+- Does it prevent per-round backlink pollution?
+- Does it clearly separate local context, useful note, useful log, GitHub
+  structural task, MotherTree review, and approved update packet?
+- Should it become global window guardrail?
+- Should it remain Qinyi-only?
+- Should it be downgraded to local operating note?
+
+---
+
+## 7. Acceptance Criteria
+
+- Default route remains Stay Local.
+- GitHub receives structural tasks only, not raw window work content.
+- Jules / Codex normalize but do not approve.
+- MotherTree remains final pollution review and closure gate.
+- Qinyi update packet is generated only after MotherTree approval.
+- This issue must not be treated as direct Qinyi update.
+
+---
+
+## 8. Requested MotherTree Decision
+
+- **Proposed_Decision:** Conditional Pass
+- **Decision_Needed:** Go / No-Go / Conditional Pass
+- **Scope_To_Decide:**
+  - global_guardrail
+  - qinyi_only
+  - local_operating_note
+  - rejected
+- **Return_Path:**
+  - GitHub Structural Task
+  - Jules / Codex Normalize
+  - MotherTree Pollution Review
+  - Approved Packet only if passed
+
+---
+
+## 9. mismatch_or_gap
+- The exact mapping between "local operating note" and the repository structure
+  is not fully defined.
+
+## 10. unresolved_risks
+- Potential for "useful logs" to still contain raw window content if
+  normalization is not strictly followed.
+
+## 11. next_single_recommended_action
+- Finalize the MotherTree review for this candidate packet and define the
+  approved rule packet format if a Conditional Pass is granted.

--- a/REPOSITORY_CORPUS_INDEX.md
+++ b/REPOSITORY_CORPUS_INDEX.md
@@ -87,6 +87,8 @@
   writeback.
 - 04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md: Video output node specification.
 - PHYSICAL_SIGNAL_BOUNDARY_SPEC.md: Physical signal entry boundary spec.
+- 03_field-governance/QINYI_SELF_RETURN_STRUCTURAL_BOUNDARY_SPEC.md: Qinyi
+  self-return structural boundary specification.
 
 - MULTI_CHAIN_DISPATCH_GOVERNANCE.md: Multi-chain dispatch governance
   specification.

--- a/UNIFIED_ARTIFACT_REGISTER.md
+++ b/UNIFIED_ARTIFACT_REGISTER.md
@@ -47,6 +47,7 @@
 - 04_adapter-layer/gemini_gas_sheet_bridge_spec.md
 - 04_adapter-layer/VIDEO_OUTPUT_NODE_SPEC.md
 - PHYSICAL_SIGNAL_BOUNDARY_SPEC.md
+- 03_field-governance/QINYI_SELF_RETURN_STRUCTURAL_BOUNDARY_SPEC.md
 
 ### Group D — Governance & Cleanup
 - MULTI_CHAIN_DISPATCH_GOVERNANCE.md


### PR DESCRIPTION
This submission formalizes the "Long-Chain Return Gate" and "Qinyi Self-Return Structural Boundary" as requested in the MotherTree intake packet GH-STRUCT-QINYI-SELF-RETURN-001.

Key changes:
1. Created `03_field-governance/QINYI_SELF_RETURN_STRUCTURAL_BOUNDARY_SPEC.md` containing all 8 requested governance sections.
2. Defined explicit trigger conditions for opening GitHub Structural Tasks versus staying local.
3. Clarified the roles of Jules (content-structure separation) and Codex (schema formalization) in the return chain.
4. Registered the new specification in `REPOSITORY_CORPUS_INDEX.md` and `UNIFIED_ARTIFACT_REGISTER.md` for proper artifact tracking.
5. Ensured all new and modified content adheres to the 80-character line length limit and architectural constraints.

Fixes #169

---
*PR created automatically by Jules for task [12478164595831223354](https://jules.google.com/task/12478164595831223354) started by @chenchienheng*