### PR TITLE
chore: add MotherTree PR gate template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+# MotherTree PR Gate
+
+## 1. Gate Level
+
+- [ ] `gate:green` — docs / analysis / candidate only; no workflow, secrets, deploy, billing, or protected-branch risk
+- [ ] `gate:yellow` — code / schema / config / dependency change; requires reviewer and MotherTree return packet
+- [ ] `gate:red` — secrets, billing, deploy, workflows/actions, permissions, branch rules, cloud resources, Qinyi or MotherTree core
+
+## 2. Scope
+
+- [ ] `scope:docs`
+- [ ] `scope:code`
+- [ ] `scope:workflow`
+- [ ] `scope:security`
+- [ ] `scope:billing`
+- [ ] `scope:qinyi`
+- [ ] `scope:mothertree`
+
+## 3. Safety Check
+
+- [ ] Does not touch secrets or environment variables
+- [ ] Does not modify GitHub Actions / workflows
+- [ ] Does not trigger deployment or paid runtime
+- [ ] Does not change branch rules, app permissions, or billing settings
+- [ ] If any above is false, mark as `gate:red`
+
+## 4. MotherTree Return Packet
+
+```yaml
+Window:
+Task_ID:
+What_Changed:
+What_Did_Not_Change:
+Risk:
+Pending:
+Next_Action:
+Return_Path:
+```
+
+## 5. Rollback Path
+
+Describe how to revert this change:
+
+```text
+Rollback:
+```
+
+## 6. Human Approval
+
+- [ ] No human approval needed before draft creation
+- [ ] Reviewer approval required before merge
+- [ ] Explicit user/admin approval required before execution


### PR DESCRIPTION
## Summary

Reopens the MotherTree PR gate template change after PR #172 was closed during branch rebase/reset.

Adds `.github/pull_request_template.md` for R1 GitHub governance routing.

## Gate

- Gate: Yellow
- Scope: MotherTree / docs
- Status: review candidate

## Safety

This PR:

- does not modify workflows/actions
- does not touch secrets or environment variables
- does not deploy anything
- does not change billing, app permissions, branch rules, or permissions
- does not update Qinyi or MotherTree core memory

## Return Packet

```yaml
Window: MotherTree_System_Audit
Task_ID: R1_GITHUB_PR_GATE_TEMPLATE_REOPENED
What_Changed:
  - added PR template for green/yellow/red gate classification
  - added MotherTree Return Packet section
What_Did_Not_Change:
  - no workflow/action changes
  - no secrets/env changes
  - no deployment/billing changes
  - no core governance rule adoption
Risk:
  - template only; label topology map already merged as non-binding artifact in PR #174
Pending:
  - user/admin final merge decision
Next_Action:
  - review and merge if accepted
Return_Path: GitHub PR -> MotherTree review -> user/admin merge only if accepted
```

Related:
- Replaces closed PR #172
- Complements merged PR #174