### PR TITLE
🧹 code health: deprecate obsolete daily generic reporting lane

### DIFF
--- a/SCHEDULING_EFFECT_REGISTER.md
+++ b/SCHEDULING_EFFECT_REGISTER.md
@@ -40,7 +40,7 @@ Each scheduling item should eventually include:
 | Schedule Name | Owner Window | Cadence | Trigger Type | Expected Output | Writeback Surface | Drift Flag | Status |
 |---|---|---|---|---|---|---|---|
 | central_reanchor_review | `00` | per major change / per contradiction escalation | event-driven | adjudication decision or return direction | durable note / issue / register update | visible if missing during major state shift | planned |
-| timeline_schedule_review | `06` | daily or per scheduling change | time-based | updated timeline/schedule state | scheduling note / timeline artifact | visible if cadence named but no update proof | planned |
+| timeline_schedule_review | `06` | 3-day convergence or per scheduling change | time-based | updated timeline/schedule state | scheduling note / timeline artifact | visible if cadence named but no update proof | planned |
 | board_orchestration_review | `03` | recurring review + event-driven | hybrid | routing refresh / queue movement / next actions | board note / issue / register | visible if tasks accumulate without routing update | planned |
 | log_writeback_append | `08` | on event + periodic archive cadence | hybrid | log entry or audit append | log board / writeback artifact | visible if actions happen without durable trace | planned |
 | toolchain_status_refresh | `10` | per tool change + maintenance cadence | hybrid | toolchain state update / routing check | tool/orchestration note | visible if tool conditions change without reflected state | planned |

--- a/SCHEDULING_RECONCILIATION_REPORT.md
+++ b/SCHEDULING_RECONCILIATION_REPORT.md
@@ -13,7 +13,7 @@ However, the current `SCHEDULING_EFFECT_REGISTER.md` relies on an older 12-windo
 ## 2. Mismatch or Gap Report
 
 ### Mismatched Schedules (Existing but mapped outside new topology):
-- `timeline_schedule_review`: Mapped to `06`. Uses "daily" cadence, which violates the rule "no daily generic reporting lane should remain active".
+- `timeline_schedule_review`: Mapped to `06`. The deprecated daily reporting lane has been removed; routine timeline convergence now belongs to `02_CVG_3D` and critical changes remain event-driven via `01_RT_Critical` or `00_ScheduleHub`.
 - `board_orchestration_review`: Mapped to `03`. The new `03_STAGE_W1` is strictly for weekly stage reporting, whereas this item uses a "recurring review + event-driven" hybrid cadence.
 - `log_writeback_append`: Mapped to `08`.
 - `toolchain_status_refresh`: Mapped to `10`.
@@ -27,7 +27,7 @@ However, the current `SCHEDULING_EFFECT_REGISTER.md` relies on an older 12-windo
 - `04_MANUAL_Doctrine`: No explicit schedules bound to manual architecture/governance work.
 
 ### Cadence Drifts:
-- The rule states "no daily generic reporting lane should remain active", but `timeline_schedule_review` enforces a daily cadence.
+- The obsolete daily cadence for `timeline_schedule_review` has been removed.
 - The 3-day and weekly cadences are named in the topology but are not actively producing outputs in the register.
 
 ## 3. Unresolved Risks


### PR DESCRIPTION
🎯 **What:** Deprecated the obsolete daily generic reporting lane from the scheduling topology mapping files.
💡 **Why:** To improve codebase health by aligning with the established scheduler topology (`PLATFORM_SCHEDULER_AND_TOOL_NAMING_MAP.md`) and enforcing the rule that "no daily generic reporting lane should remain active", routing routine convergence to `02_CVG_3D` and critical changes to `01_RT_Critical` / `00_ScheduleHub`.
✅ **Verification:** Ensured changes were strictly localized to `SCHEDULING_RECONCILIATION_REPORT.md` and `SCHEDULING_EFFECT_REGISTER.md`, following negative constraints (e.g., did not touch `WINDOW_12_MASTER_TABLE.md` or collapse topologies). Verified changes exist correctly in the codebase.
✨ **Result:** Maintained topology hygiene without broad structural rewrites, resolving the timeline schedule review cadence drift mismatch.

---
*PR created automatically by Jules for task [11011613382975035396](https://jules.google.com/task/11011613382975035396) started by @chenchienheng*