### PR TITLE
🔒 Fix: Add candidate boundary rate limiting requirement to spec

### DIFF
--- a/EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
+++ b/EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
@@ -57,7 +57,22 @@ considered compliant with the runtime:
   warning, breaking the entry chain if schema validation is not strictly
   enforced at the boundary.
 
+### Boundary Rate Limiting Requirement (Candidate)
+External signals entering the chain must pass through an edge limiter before being accepted into downstream routing. **Note: Until implemented, this remains a candidate security requirement and not runtime protection.**
+
+The expected control semantics for the edge limiter are:
+- **Per-source Rate Limit:** A strict cap on the number of signals per source (e.g., per IP, API key, or origin identifier) within a defined time window.
+- **Burst Threshold:** An allowable burst capacity that slightly exceeds the standard limit for brief intervals before triggering limits.
+- **Cooldown / Backoff:** An enforced waiting period or exponential backoff applied to sources exceeding their threshold.
+- **Queue or Drop Behavior:** A defined policy determining whether excess signals are placed in a holding queue (for asynchronous retry) or immediately dropped.
+- **Priority Override:** Trusted sources or manual operator interventions may bypass standard limits under controlled conditions.
+- **Logging / Audit Trail:** Every rate-limit trigger must generate an auditable log entry for monitoring bot floods or sensor malfunctions.
+- **Failure Mode:** If the rate limiter itself fails, it should default to a "fail-closed" or highly restricted state to prevent cascading failure of the primary chain.
+- **Return Path:** Blocked or flooded signals should return an explicit "rate-limited" status to the origin and route a failure notification to AXIS-05 for human review.
+
 ### Next Single Recommended Action
 - Create a lightweight schema validation template for inbound payloads that
   can be applied universally to all entry nodes before they are allowed onto
   the primary AXIS-01 track.
+- Define a standard rate-limiter and cost-bounding template at the edge of
+  the chain to mitigate signal flooding and cascading failures.


### PR DESCRIPTION
```yaml
Jules_Return_Packet:
  Gate: Yellow
  Scope: EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
  Files_Changed:
    - EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
  What_Changed: |
    Added a "Boundary Rate Limiting Requirement (Candidate)" section defining expected
    control semantics (per-source limits, burst thresholds, cooldowns, queue/drop behavior,
    priority overrides, logging, failure mode, and return path) to address the
    "Missing Rate Limiting at Boundary" unresolved risk. Also updated the "Next Single Recommended Action" to include this mitigation.
  What_Did_Not_Change: |
    No runtime code was implemented. No dependencies were added. Core architecture, workflows,
    and governance rules were not modified. The change is strictly a docs-only candidate update.
  Risk: Low. The change is isolated to a documentation specification and explicitly labeled as a candidate requirement, ensuring it is not mistaken for active runtime protection.
  Pending: Formal approval and eventual runtime implementation of the rate limiter.
  Rollback: Revert commit to restore previous specification text.
  Next_Action: Formalize requirement or begin implementation planning for boundary rate limiting.
```

---
*PR created automatically by Jules for task [14088740403219618109](https://jules.google.com/task/14088740403219618109) started by @chenchienheng*