### PR TITLE
🔒 Fix: Enforce schema validation at entry boundary

### DIFF
--- a/EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
+++ b/EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
@@ -70,6 +70,28 @@ The expected control semantics for the edge limiter are:
 - **Failure Mode:** If the rate limiter itself fails, it should default to a "fail-closed" or highly restricted state to prevent cascading failure of the primary chain.
 - **Return Path:** Blocked or flooded signals should return an explicit "rate-limited" status to the origin and route a failure notification to AXIS-05 for human review.
 
+### Schema Validation Requirement (Candidate)
+External signals entering the chain must be strictly validated against a defined schema template at the boundary before processing. **Note: Until implemented, this remains a candidate security requirement and not runtime protection.**
+
+The expected control semantics for the schema validation are:
+- **Strict Typing and Structure:** All inbound payloads must match an explicit structure (e.g., required headers, body fields, and metadata). Unknown fields must be rejected or stripped.
+- **Boundary Rejection/Hold:** Payloads failing schema validation must be immediately rejected at the entry node or held in a dead-letter queue. They must not propagate to the primary AXIS-01 track.
+- **Error Handling & Return Path:** A standardized error response must be returned to the origin when possible, and failure notifications routed to AXIS-05 for human review.
+- **Evidence Logging:** Every schema rejection must generate a sanitized log entry (without recording potentially malicious payload bodies) to detect format drift or targeted fuzzing.
+- **Schema Versioning:** The validation template must enforce versioning to allow controlled transitions when external APIs update their formats, mitigating unexpected breakage.
+
+**Minimal Example Validation Template:**
+```json
+{
+  "entry_node_id": "REQ-String",
+  "payload_version": "REQ-String(v1.0)",
+  "timestamp": "REQ-ISO8601",
+  "data": "REQ-Object(StrictSchema)",
+  "metadata": "OPT-Object"
+}
+```
+*Note: Any payload missing required fields or containing invalid types must be dropped and logged. This is an architectural spec; no CVE or dependency advisory applies here.*
+
 ### Next Single Recommended Action
 - Create a lightweight schema validation template for inbound payloads that
   can be applied universally to all entry nodes before they are allowed onto

--- a/EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
+++ b/EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
@@ -75,7 +75,7 @@ External signals entering the chain must be strictly validated against a defined
 
 The expected control semantics for the schema validation are:
 - **Strict Typing and Structure:** All inbound payloads must match an explicit structure (e.g., required headers, body fields, and metadata). Unknown fields must be rejected or stripped.
-- **Boundary Rejection/Hold:** Payloads failing schema validation must be immediately rejected at the entry node or held in a dead-letter queue. They must not propagate to the primary AXIS-01 track.
+- **Boundary Rejection/Hold:** Payloads failing schema validation must be immediately rejected at the entry node or held in a quarantine / review state. They must not propagate to the primary AXIS-01 track. (Note: Implementation of any concrete queue, middleware, or database to handle this hold state remains Pending / Red Gate).
 - **Error Handling & Return Path:** A standardized error response must be returned to the origin when possible, and failure notifications routed to AXIS-05 for human review.
 - **Evidence Logging:** Every schema rejection must generate a sanitized log entry (without recording potentially malicious payload bodies) to detect format drift or targeted fuzzing.
 - **Schema Versioning:** The validation template must enforce versioning to allow controlled transitions when external APIs update their formats, mitigating unexpected breakage.


### PR DESCRIPTION
```yaml
Jules_Return_Packet:
  Gate: Yellow
  Scope: EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md around line 56
  Files_Changed: EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md
  What_Changed: Added a "Schema Validation Requirement (Candidate)" section after the rate limit requirement. Included strict typing rules, boundary rejection/hold behavior, error handling and return paths, and evidence logging. Provided a minimal JSON example payload template.
  What_Did_Not_Change: No existing policies were altered or removed. No runtime logic, automated validations, API connections, workflows, or actual gateway implementations were introduced. No core doctrine was rewritten.
  Risk: Low. The change is isolated to a documentation/specification update and explicitly marked as a "candidate security requirement and not runtime protection" to prevent misinterpretation as active code.
  Pending: Actual deployment and implementation of a runtime schema validation gateway (which is a Red Gate task).
  Rollback: Revert the PR or remove the newly added section using git diff.
  Next_Action: Merge the PR to establish the documentation baseline for future implementation reference, or Hold for MotherTree review.
```

🎯 **What:** An Unvalidated Input Schema vulnerability (Format Drift) at the boundary was identified in the `EXTERNAL_SIGNAL_ENTRY_CHAIN_SPEC.md` specification. The system lacked defined criteria for structured schema validation of inbound payloads.
⚠️ **Risk:** Without a documented and enforceable validation schema at the entry node, the system risks cascading failures, malicious data ingestion, or logic breaks when external APIs update their formats silently.
🛡️ **Solution:** Implemented a new `Schema Validation Requirement (Candidate)` documentation section. This adds definitions for strict typing, rejection and holding behavior, error routing to AXIS-05, and sanitized evidence logging. A minimal example JSON schema template is provided. 

*Note: As this is an architectural spec in a documentation repository, a CVE or dependency advisory search is not applicable. No CVE references apply.*

---
*PR created automatically by Jules for task [18064471335839272545](https://jules.google.com/task/18064471335839272545) started by @chenchienheng*