### PR TITLE
Add CloudTop / Registry boundary split candidate v0.1

### DIFF
--- a/03_field-governance/CLOUDTOP_REGISTRY_BOUNDARY_SPLIT_v0_1.md
+++ b/03_field-governance/CLOUDTOP_REGISTRY_BOUNDARY_SPLIT_v0_1.md
@@ -1,0 +1,112 @@
+# CloudTop / Registry Boundary Split v0.1
+
+> Status: Candidate / review packet
+> Related issue: #167
+> Purpose: separate company data work surfaces from return-governance record surfaces before any formal rule review.
+
+---
+
+## 1. Core
+
+CloudTop and GitHub / Registry Tree are different layers.
+
+CloudTop is the company data and source-view work surface. GitHub / Registry Tree is the governance, review, lineage, and return-path record surface.
+
+This file is not an approved doctrine. It is candidate split evidence for review.
+
+---
+
+## 2. CloudTop / Drive Layer
+
+```yaml
+CloudTop_Drive_Layer:
+  role: company data / ERP-CRM-knowledge-base pre-structure / Taiwan strategy DB carrier
+  may_hold:
+    - source ledger
+    - entity records
+    - claim / matrix / view candidates
+    - GM View candidates
+    - CWC company-level records
+    - capability / role / link / source fields
+  output_type:
+    - company-data structure
+    - source-view work surface
+  required_gates:
+    - source-view separation
+    - evidence boundary
+    - company-sensitive data boundary
+    - GM View hardening
+```
+
+---
+
+## 3. GitHub / Registry Tree Layer
+
+```yaml
+GitHub_Registry_Tree_Layer:
+  role: return-chain governance / window protocols / structural rules / MotherTree review tasks
+  may_hold:
+    - boundary rules
+    - review tasks
+    - return-path governance
+    - issue / PR lineage
+    - candidate patch tasks
+  output_type:
+    - governance record
+    - candidate rule
+    - review packet
+  required_gates:
+    - Candidate vs Approved
+    - Return Packet vs Closeout
+    - issue / PR trace
+    - MotherTree review
+```
+
+---
+
+## 4. Separation Rule
+
+```yaml
+Separation_Rule:
+  CloudTop_View:
+    can_support: company-side data work and strategy view preparation
+    cannot_support: final governance rule by itself
+
+  GitHub_Governance_Record:
+    can_support: structural review, lineage, boundary rule candidate, and return path
+    cannot_support: live company database or company-sensitive operating source by itself
+```
+
+---
+
+## 5. Bridge Rule
+
+CloudTop may generate company views, source ledgers, or strategy packets. Those views become governance material only after review and return through GitHub / Registry Tree.
+
+GitHub may record rules, reviews, and return paths. It does not replace the company data layer.
+
+Qinyi Assistant updates remain downstream of MotherTree review and must not be generated directly from this candidate file.
+
+---
+
+## 6. Minimal Review Checklist
+
+```yaml
+Review_Checklist:
+  - Is CloudTop clearly scoped as company data / source-view work surface?
+  - Is GitHub clearly scoped as governance / review / return-path surface?
+  - Does this preserve Candidate / Approved separation?
+  - Does this avoid mixing company data with registry governance?
+  - Is a later formal rule file needed?
+```
+
+---
+
+## 7. Current Decision
+
+```yaml
+Decision: Conditional_Pass_Candidate
+Status: Candidate_Boundary_Split
+Review_State: needs_MotherTree_review
+Return_Path: Issue #167 -> candidate PR -> MotherTree review -> explicit Go / Conditional Pass / No-Go
+```


### PR DESCRIPTION
## Core

Add `03_field-governance/CLOUDTOP_REGISTRY_BOUNDARY_SPLIT_v0_1.md` as a candidate boundary split file for Issue #167.

This PR turns the #167 split evidence into a reviewable artifact. It does not approve the rule and does not modify main directly.

## Scope

- Define CloudTop / Drive as company data and source-view work surface.
- Define GitHub / Registry Tree as governance, review, lineage, and return-path record surface.
- Preserve MotherTree review before any formal boundary rule.
- Keep Qinyi Assistant update downstream of review.

## Boundary

- Candidate file only.
- Not approved doctrine.
- Not production system.
- Not CloudTop / Drive mutation.
- Not Qinyi Assistant update.
- Not runtime / API / MCP / billing / automation.

## Return Path

Issue #167 -> candidate boundary split PR -> MotherTree review -> explicit Go / Conditional Pass / No-Go.

## Review Focus

1. Is CloudTop scoped clearly as company data / source-view work surface?
2. Is GitHub / Registry Tree scoped clearly as governance / review / return-path surface?
3. Does the candidate preserve Candidate / Approved separation?
4. Should this become a formal boundary rule after review?